### PR TITLE
add packagist support

### DIFF
--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -90,6 +90,8 @@ function getRegistryLabel(registry: Registry): string {
       return "PyPI";
     case "crates":
       return "crates.io";
+    case "packagist":
+      return "Packagist";
   }
 }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -10,6 +10,7 @@ const REGISTRY_LABELS: Record<Registry, string> = {
   npm: "npm",
   pypi: "PyPI",
   crates: "crates.io",
+  packagist: "Packagist",
 };
 
 /**
@@ -28,9 +29,10 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
     );
     console.log("Use `opensrc <owner>/<repo>` to fetch a GitHub repository.");
     console.log("\nSupported registries:");
-    console.log("  • npm:      opensrc zod, opensrc npm:react");
-    console.log("  • PyPI:     opensrc pypi:requests");
-    console.log("  • crates:   opensrc crates:serde");
+    console.log("  • npm:       opensrc zod, opensrc npm:react");
+    console.log("  • PyPI:      opensrc pypi:requests");
+    console.log("  • crates:    opensrc crates:serde");
+    console.log("  • Packagist: opensrc packagist:laravel/framework");
     return;
   }
 
@@ -44,6 +46,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
     npm: [],
     pypi: [],
     crates: [],
+    packagist: [],
   };
 
   for (const pkg of sources.packages) {
@@ -51,7 +54,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
   }
 
   // Display packages by registry
-  const registries: Registry[] = ["npm", "pypi", "crates"];
+  const registries: Registry[] = ["npm", "pypi", "crates", "packagist"];
   let hasDisplayedPackages = false;
 
   for (const registry of registries) {

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -76,7 +76,7 @@ export async function removeCommand(
 
       if (!pkgInfo) {
         // Try other registries if default didn't work
-        const registries: Registry[] = ["npm", "pypi", "crates"];
+        const registries: Registry[] = ["npm", "pypi", "crates", "packagist"];
         for (const reg of registries) {
           if (reg !== registry) {
             pkgInfo = await getPackageInfo(cleanSpec, cwd, reg);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ program
 program
   .argument(
     "[packages...]",
-    "packages or repos to fetch (e.g., zod, pypi:requests, crates:serde, owner/repo)",
+    "packages or repos to fetch (e.g., zod, pypi:requests, crates:serde, packagist:laravel/framework, owner/repo)",
   )
   .option("--cwd <path>", "working directory (default: current directory)")
   .option(
@@ -80,6 +80,7 @@ program
   .option("--npm", "only remove npm packages")
   .option("--pypi", "only remove PyPI packages")
   .option("--crates", "only remove crates.io packages")
+  .option("--packagist", "only remove Packagist packages")
   .option("--cwd <path>", "working directory (default: current directory)")
   .action(
     async (options: {
@@ -88,6 +89,7 @@ program
       npm?: boolean;
       pypi?: boolean;
       crates?: boolean;
+      packagist?: boolean;
       cwd?: string;
     }) => {
       // Determine registry from flags
@@ -95,6 +97,7 @@ program
       if (options.npm) registry = "npm";
       else if (options.pypi) registry = "pypi";
       else if (options.crates) registry = "crates";
+      else if (options.packagist) registry = "packagist";
 
       await cleanCommand({
         packages: options.packages || !!registry,

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -29,10 +29,11 @@ Use this source code when you need to understand how a package works internally,
 To fetch source code for a package or repository you need to understand, run:
 
 \`\`\`bash
-npx opensrc <package>           # npm package (e.g., npx opensrc zod)
-npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
-npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
-npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
+npx opensrc <package>              # npm package (e.g., npx opensrc zod)
+npx opensrc pypi:<package>         # Python package (e.g., npx opensrc pypi:requests)
+npx opensrc crates:<package>       # Rust crate (e.g., npx opensrc crates:serde)
+npx opensrc packagist:<package>    # PHP package (e.g., npx opensrc packagist:laravel/framework)
+npx opensrc <owner>/<repo>         # GitHub repo (e.g., npx opensrc vercel/ai)
 \`\`\`
 
 ${SECTION_END_MARKER}`;

--- a/src/lib/registries/index.test.ts
+++ b/src/lib/registries/index.test.ts
@@ -85,6 +85,36 @@ describe("detectRegistry", () => {
     });
   });
 
+  describe("packagist registry", () => {
+    it("detects packagist: prefix", () => {
+      expect(detectRegistry("packagist:laravel/framework")).toEqual({
+        registry: "packagist",
+        cleanSpec: "laravel/framework",
+      });
+    });
+
+    it("detects composer: prefix", () => {
+      expect(detectRegistry("composer:laravel/framework")).toEqual({
+        registry: "packagist",
+        cleanSpec: "laravel/framework",
+      });
+    });
+
+    it("detects php: prefix", () => {
+      expect(detectRegistry("php:symfony/symfony")).toEqual({
+        registry: "packagist",
+        cleanSpec: "symfony/symfony",
+      });
+    });
+
+    it("handles case-insensitive prefixes", () => {
+      expect(detectRegistry("PACKAGIST:laravel/framework")).toEqual({
+        registry: "packagist",
+        cleanSpec: "laravel/framework",
+      });
+    });
+  });
+
   describe("preserves version in cleanSpec", () => {
     it("npm with version", () => {
       expect(detectRegistry("npm:lodash@4.17.21")).toEqual({
@@ -104,6 +134,20 @@ describe("detectRegistry", () => {
       expect(detectRegistry("crates:serde@1.0.0")).toEqual({
         registry: "crates",
         cleanSpec: "serde@1.0.0",
+      });
+    });
+
+    it("packagist with version", () => {
+      expect(detectRegistry("packagist:laravel/framework@11.0.0")).toEqual({
+        registry: "packagist",
+        cleanSpec: "laravel/framework@11.0.0",
+      });
+    });
+
+    it("packagist with composer-style version", () => {
+      expect(detectRegistry("composer:monolog/monolog:^3.0")).toEqual({
+        registry: "packagist",
+        cleanSpec: "monolog/monolog:^3.0",
       });
     });
   });
@@ -179,6 +223,32 @@ describe("parsePackageSpec", () => {
       });
     });
   });
+
+  describe("packagist packages", () => {
+    it("parses packagist package", () => {
+      expect(parsePackageSpec("packagist:laravel/framework")).toEqual({
+        registry: "packagist",
+        name: "laravel/framework",
+        version: undefined,
+      });
+    });
+
+    it("parses packagist package with @ version", () => {
+      expect(parsePackageSpec("php:laravel/framework@11.0.0")).toEqual({
+        registry: "packagist",
+        name: "laravel/framework",
+        version: "11.0.0",
+      });
+    });
+
+    it("parses packagist package with : version (Composer style)", () => {
+      expect(parsePackageSpec("composer:monolog/monolog:^3.0")).toEqual({
+        registry: "packagist",
+        name: "monolog/monolog",
+        version: "^3.0",
+      });
+    });
+  });
 });
 
 describe("detectInputType", () => {
@@ -201,6 +271,18 @@ describe("detectInputType", () => {
 
     it("crates package", () => {
       expect(detectInputType("crates:serde")).toBe("package");
+    });
+
+    it("packagist package", () => {
+      expect(detectInputType("packagist:laravel/framework")).toBe("package");
+    });
+
+    it("composer package", () => {
+      expect(detectInputType("composer:symfony/symfony")).toBe("package");
+    });
+
+    it("php package", () => {
+      expect(detectInputType("php:guzzlehttp/guzzle")).toBe("package");
     });
 
     it("package with version", () => {

--- a/src/lib/registries/index.test.ts
+++ b/src/lib/registries/index.test.ts
@@ -143,13 +143,6 @@ describe("detectRegistry", () => {
         cleanSpec: "laravel/framework@11.0.0",
       });
     });
-
-    it("packagist with composer-style version", () => {
-      expect(detectRegistry("composer:monolog/monolog:^3.0")).toEqual({
-        registry: "packagist",
-        cleanSpec: "monolog/monolog:^3.0",
-      });
-    });
   });
 });
 
@@ -238,14 +231,6 @@ describe("parsePackageSpec", () => {
         registry: "packagist",
         name: "laravel/framework",
         version: "11.0.0",
-      });
-    });
-
-    it("parses packagist package with : version (Composer style)", () => {
-      expect(parsePackageSpec("composer:monolog/monolog:^3.0")).toEqual({
-        registry: "packagist",
-        name: "monolog/monolog",
-        version: "^3.0",
       });
     });
   });

--- a/src/lib/registries/index.ts
+++ b/src/lib/registries/index.ts
@@ -2,11 +2,13 @@ import type { Registry, PackageSpec, ResolvedPackage } from "../../types.js";
 import { parseNpmSpec, resolveNpmPackage } from "./npm.js";
 import { parsePyPISpec, resolvePyPIPackage } from "./pypi.js";
 import { parseCratesSpec, resolveCrate } from "./crates.js";
+import { parsePackagistSpec, resolvePackagistPackage } from "./packagist.js";
 import { isRepoSpec } from "../repo.js";
 
 export { resolveNpmPackage } from "./npm.js";
 export { resolvePyPIPackage } from "./pypi.js";
 export { resolveCrate } from "./crates.js";
+export { resolvePackagistPackage } from "./packagist.js";
 
 /**
  * Registry prefixes for explicit specification
@@ -19,6 +21,9 @@ const REGISTRY_PREFIXES: Record<string, Registry> = {
   "crates:": "crates",
   "cargo:": "crates",
   "rust:": "crates",
+  "packagist:": "packagist",
+  "composer:": "packagist",
+  "php:": "packagist",
 };
 
 /**
@@ -67,6 +72,9 @@ export function parsePackageSpec(spec: string): PackageSpec {
     case "crates":
       ({ name, version } = parseCratesSpec(cleanSpec));
       break;
+    case "packagist":
+      ({ name, version } = parsePackagistSpec(cleanSpec));
+      break;
   }
 
   return { registry, name, version };
@@ -87,6 +95,8 @@ export async function resolvePackage(
       return resolvePyPIPackage(name, version);
     case "crates":
       return resolveCrate(name, version);
+    case "packagist":
+      return resolvePackagistPackage(name, version);
   }
 }
 

--- a/src/lib/registries/packagist.test.ts
+++ b/src/lib/registries/packagist.test.ts
@@ -48,29 +48,6 @@ describe("parsePackagistSpec", () => {
     });
   });
 
-  describe(": version specifier (Composer style)", () => {
-    it("parses package:version", () => {
-      expect(parsePackagistSpec("laravel/framework:11.0.0")).toEqual({
-        name: "laravel/framework",
-        version: "11.0.0",
-      });
-    });
-
-    it("parses with caret constraint", () => {
-      expect(parsePackagistSpec("monolog/monolog:^3.0")).toEqual({
-        name: "monolog/monolog",
-        version: "^3.0",
-      });
-    });
-
-    it("parses with tilde constraint", () => {
-      expect(parsePackagistSpec("phpunit/phpunit:~10.5")).toEqual({
-        name: "phpunit/phpunit",
-        version: "~10.5",
-      });
-    });
-  });
-
   describe("edge cases", () => {
     it("handles whitespace trimming", () => {
       expect(parsePackagistSpec("  laravel/framework  ")).toEqual({

--- a/src/lib/registries/packagist.test.ts
+++ b/src/lib/registries/packagist.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { parsePackagistSpec } from "./packagist.js";
+
+describe("parsePackagistSpec", () => {
+  describe("package name only", () => {
+    it("parses simple vendor/package name", () => {
+      expect(parsePackagistSpec("laravel/framework")).toEqual({
+        name: "laravel/framework",
+        version: undefined,
+      });
+    });
+
+    it("parses package with hyphens", () => {
+      expect(parsePackagistSpec("symfony/http-foundation")).toEqual({
+        name: "symfony/http-foundation",
+        version: undefined,
+      });
+    });
+
+    it("parses package with underscores", () => {
+      expect(parsePackagistSpec("doctrine/dbal")).toEqual({
+        name: "doctrine/dbal",
+        version: undefined,
+      });
+    });
+  });
+
+  describe("@ version specifier", () => {
+    it("parses package@version", () => {
+      expect(parsePackagistSpec("laravel/framework@11.0.0")).toEqual({
+        name: "laravel/framework",
+        version: "11.0.0",
+      });
+    });
+
+    it("parses complex package name@version", () => {
+      expect(parsePackagistSpec("symfony/http-foundation@7.0.0")).toEqual({
+        name: "symfony/http-foundation",
+        version: "7.0.0",
+      });
+    });
+
+    it("parses with v prefix in version", () => {
+      expect(parsePackagistSpec("guzzlehttp/guzzle@v7.8.0")).toEqual({
+        name: "guzzlehttp/guzzle",
+        version: "v7.8.0",
+      });
+    });
+  });
+
+  describe(": version specifier (Composer style)", () => {
+    it("parses package:version", () => {
+      expect(parsePackagistSpec("laravel/framework:11.0.0")).toEqual({
+        name: "laravel/framework",
+        version: "11.0.0",
+      });
+    });
+
+    it("parses with caret constraint", () => {
+      expect(parsePackagistSpec("monolog/monolog:^3.0")).toEqual({
+        name: "monolog/monolog",
+        version: "^3.0",
+      });
+    });
+
+    it("parses with tilde constraint", () => {
+      expect(parsePackagistSpec("phpunit/phpunit:~10.5")).toEqual({
+        name: "phpunit/phpunit",
+        version: "~10.5",
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles whitespace trimming", () => {
+      expect(parsePackagistSpec("  laravel/framework  ")).toEqual({
+        name: "laravel/framework",
+        version: undefined,
+      });
+    });
+
+    it("handles dev versions", () => {
+      expect(parsePackagistSpec("laravel/framework@dev-master")).toEqual({
+        name: "laravel/framework",
+        version: "dev-master",
+      });
+    });
+
+    it("handles prerelease versions", () => {
+      expect(parsePackagistSpec("laravel/framework@11.0.0-alpha.1")).toEqual({
+        name: "laravel/framework",
+        version: "11.0.0-alpha.1",
+      });
+    });
+
+    it("handles beta versions", () => {
+      expect(parsePackagistSpec("symfony/symfony:7.0.0-beta1")).toEqual({
+        name: "symfony/symfony",
+        version: "7.0.0-beta1",
+      });
+    });
+
+    it("handles package without vendor prefix as-is", () => {
+      expect(parsePackagistSpec("somepackage")).toEqual({
+        name: "somepackage",
+        version: undefined,
+      });
+    });
+  });
+});

--- a/src/lib/registries/packagist.ts
+++ b/src/lib/registries/packagist.ts
@@ -1,0 +1,232 @@
+import type { ResolvedPackage } from "../../types.js";
+
+const PACKAGIST_API = "https://repo.packagist.org/p2";
+
+interface PackagistVersion {
+  version: string;
+  version_normalized: string;
+  source?: {
+    type: string;
+    url: string;
+    reference: string;
+  };
+  time?: string;
+}
+
+interface PackagistResponse {
+  packages: {
+    [packageName: string]: PackagistVersion[];
+  };
+}
+
+/**
+ * Parse a Packagist package specifier like "laravel/framework@11.0.0" into name and version
+ */
+export function parsePackagistSpec(spec: string): {
+  name: string;
+  version?: string;
+} {
+  const trimmed = spec.trim();
+
+  // Packagist packages are in vendor/package format
+  // Handle version specifier: vendor/package@1.0.0 or vendor/package:1.0.0
+  const colonIndex = trimmed.lastIndexOf(":");
+  const atIndex = trimmed.lastIndexOf("@");
+
+  // Use whichever delimiter comes after the vendor/package part
+  // We need to be careful with @ since it could be part of the version (like dev-main@abc123)
+  // The package name always contains a /, so find that first
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex === -1) {
+    return { name: trimmed };
+  }
+
+  // Check for : version separator (Composer style: vendor/package:^1.0)
+  if (colonIndex > slashIndex) {
+    return {
+      name: trimmed.slice(0, colonIndex).trim(),
+      version: trimmed.slice(colonIndex + 1).trim(),
+    };
+  }
+
+  // Check for @ version separator
+  if (atIndex > slashIndex) {
+    return {
+      name: trimmed.slice(0, atIndex).trim(),
+      version: trimmed.slice(atIndex + 1).trim(),
+    };
+  }
+
+  return { name: trimmed };
+}
+
+/**
+ * Fetch package metadata from Packagist
+ */
+async function fetchPackagistInfo(
+  packageName: string,
+): Promise<PackagistResponse> {
+  const url = `${PACKAGIST_API}/${packageName}.json`;
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "opensrc-cli (https://github.com/vercel-labs/opensrc)",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(`Package "${packageName}" not found on Packagist`);
+    }
+    throw new Error(
+      `Failed to fetch package info: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.json() as Promise<PackagistResponse>;
+}
+
+/**
+ * Extract repository URL from package version info
+ */
+function extractRepoUrl(version: PackagistVersion): string | null {
+  if (!version.source?.url) {
+    return null;
+  }
+
+  let url = version.source.url;
+
+  // Normalize git URLs
+  url = url
+    .replace(/^git\+/, "")
+    .replace(/^git:\/\//, "https://")
+    .replace(/^git@github\.com:/, "https://github.com/")
+    .replace(/^git@gitlab\.com:/, "https://gitlab.com/")
+    .replace(/\.git$/, "");
+
+  // Only return URLs from known git hosts
+  if (isGitRepoUrl(url)) {
+    return normalizeRepoUrl(url);
+  }
+
+  return null;
+}
+
+function isGitRepoUrl(url: string): boolean {
+  return (
+    url.includes("github.com") ||
+    url.includes("gitlab.com") ||
+    url.includes("bitbucket.org")
+  );
+}
+
+function normalizeRepoUrl(url: string): string {
+  return url
+    .replace(/\/+$/, "")
+    .replace(/\.git$/, "")
+    .replace(/\/tree\/.*$/, "")
+    .replace(/\/blob\/.*$/, "");
+}
+
+/**
+ * Get available versions sorted by time (newest first)
+ * Filters out dev versions unless specifically requested
+ */
+function getAvailableVersions(
+  versions: PackagistVersion[],
+  includeDev = false,
+): PackagistVersion[] {
+  return versions
+    .filter((v) => {
+      if (includeDev) return true;
+      // Filter out dev versions (dev-*, *-dev, etc.)
+      return (
+        !v.version.startsWith("dev-") &&
+        !v.version.endsWith("-dev") &&
+        !v.version.includes("-dev@")
+      );
+    })
+    .sort((a, b) => {
+      // Sort by time if available, otherwise by version
+      if (a.time && b.time) {
+        return new Date(b.time).getTime() - new Date(a.time).getTime();
+      }
+      return b.version_normalized.localeCompare(a.version_normalized);
+    });
+}
+
+/**
+ * Resolve a Packagist package to its repository information
+ */
+export async function resolvePackagistPackage(
+  packageName: string,
+  version?: string,
+): Promise<ResolvedPackage> {
+  const info = await fetchPackagistInfo(packageName);
+  const versions = info.packages[packageName];
+
+  if (!versions || versions.length === 0) {
+    throw new Error(`No versions found for "${packageName}"`);
+  }
+
+  let resolvedVersion: PackagistVersion;
+
+  if (version) {
+    // Find the specific version requested
+    // Handle both exact match and normalized match
+    const normalizedRequest = version.replace(/^v/, "");
+    resolvedVersion =
+      versions.find(
+        (v) =>
+          v.version === version ||
+          v.version === `v${version}` ||
+          v.version_normalized === normalizedRequest ||
+          v.version_normalized.startsWith(normalizedRequest + "."),
+      ) ||
+      versions.find((v) => v.version.includes(version)) ||
+      versions[0];
+
+    if (!resolvedVersion) {
+      const availableVersions = getAvailableVersions(versions)
+        .slice(0, 5)
+        .map((v) => v.version)
+        .join(", ");
+      throw new Error(
+        `Version "${version}" not found for "${packageName}". ` +
+          `Recent versions: ${availableVersions}`,
+      );
+    }
+  } else {
+    // Get the latest stable version
+    const stableVersions = getAvailableVersions(versions);
+    resolvedVersion = stableVersions[0] || versions[0];
+  }
+
+  const repoUrl = extractRepoUrl(resolvedVersion);
+
+  if (!repoUrl) {
+    const availableVersions = getAvailableVersions(versions)
+      .slice(0, 5)
+      .map((v) => v.version)
+      .join(", ");
+    throw new Error(
+      `No repository URL found for "${packageName}@${resolvedVersion.version}". ` +
+        `This package may not have its source published. ` +
+        `Recent versions: ${availableVersions}`,
+    );
+  }
+
+  // PHP packages commonly use v1.2.3 as tags
+  const gitTag = resolvedVersion.version.startsWith("v")
+    ? resolvedVersion.version
+    : `v${resolvedVersion.version}`;
+
+  return {
+    registry: "packagist",
+    name: packageName,
+    version: resolvedVersion.version,
+    repoUrl,
+    gitTag,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * Supported package registries
  */
-export type Registry = "npm" | "pypi" | "crates";
+export type Registry = "npm" | "pypi" | "crates" | "packagist";
 
 export interface PackageInfo {
   name: string;


### PR DESCRIPTION
This PR adds support for PHP packages via Packagist.
It adds 3 aliases: `packagist`, `composer` and `php`