### PR TITLE
Add "Related Projects" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ The `settings.json` file stores your preferences:
 }
 ```
 
+## Related Projects
+
+- **[llms-furl](https://github.com/toyamarinyon/llms-furl)** — Furl `llms-full.txt` into a structured tree of small, searchable files. While opensrc fetches package source code, llms-furl splits monolithic LLM documentation into a Unix-friendly filesystem you can search with `grep`, `find`, and pipes.
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
Hi! 👋

First of all, thank you for creating opensrc — it's been a great inspiration for my work.

I built [llms-furl](https://github.com/toyamarinyon/llms-furl), a tool that takes the same Unix-philosophy approach but for llms-full.txt files. While opensrc fetches package source code for agent context, llms-furl splits monolithic LLM documentation into a searchable filesystem tree.

I was wondering if you'd be open to adding a "Related Projects" section to the README to mention llms-furl. I think it could be helpful for users who are looking for complementary tools in this space.

If you'd prefer not to include it, or if there's a different format you'd like, I'm happy to adjust. Just let me know!

---

Changes:

Added a "Related Projects" section before the License section