### PR TITLE
Use .opensrc/ dotfile directory instead of opensrc/

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ opensrc owner/repo#main
 opensrc zod facebook/react
 ```
 
-GitHub repos are stored as `opensrc/owner--repo/`.
+GitHub repos are stored as `.opensrc/owner--repo/`.
 
 ### Managing Sources
 
@@ -76,11 +76,11 @@ opensrc remove owner--repo
 
 On first run, opensrc will ask for permission to modify these files:
 
-- `.gitignore` — adds `opensrc/` to ignore list
-- `tsconfig.json` — excludes `opensrc/` from compilation
+- `.gitignore` — adds `.opensrc/` to ignore list
+- `tsconfig.json` — excludes `.opensrc/` from compilation
 - `AGENTS.md` — adds a section pointing agents to the source code
 
-Your choice is saved to `opensrc/settings.json` so you won't be prompted again.
+Your choice is saved to `.opensrc/settings.json` so you won't be prompted again.
 
 To skip the prompt, use the `--modify` flag:
 
@@ -97,15 +97,15 @@ opensrc zod --modify=false
 1. Queries the npm registry to find the package's repository URL
 2. Detects the installed version from your lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`)
 3. Clones the repository at the matching git tag
-4. Stores the source in `opensrc/<package-name>/`
-5. If permitted: adds `opensrc/` to `.gitignore`, excludes from `tsconfig.json`, updates `AGENTS.md`
+4. Stores the source in `.opensrc/<package-name>/`
+5. If permitted: adds `.opensrc/` to `.gitignore`, excludes from `tsconfig.json`, updates `AGENTS.md`
 
 ## Output
 
 After running `opensrc zod`:
 
 ```
-opensrc/
+.opensrc/
 ├── settings.json       # Your modification preferences
 ├── sources.json        # Index of fetched packages
 └── zod/
@@ -119,7 +119,7 @@ The `sources.json` file lists all fetched packages with their versions, so agent
 ```json
 {
   "packages": [
-    { "name": "zod", "version": "3.22.0", "path": "opensrc/zod" }
+    { "name": "zod", "version": "3.22.0", "path": ".opensrc/zod" }
   ]
 }
 ```

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -92,7 +92,7 @@ export async function cleanCommand(options: CleanOptions = {}): Promise<void> {
   const reposDir = getReposDir(cwd);
   for (const repoPath of allRepoPaths) {
     if (!neededRepoPaths.has(repoPath)) {
-      const fullPath = `${cwd}/opensrc/${repoPath}`;
+      const fullPath = `${cwd}/.opensrc/${repoPath}`;
       if (existsSync(fullPath)) {
         await rm(fullPath, { recursive: true, force: true });
       }

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -62,8 +62,8 @@ async function checkFileModificationPermission(
   console.log(
     "\nopensrc can update the following files for better integration:",
   );
-  console.log("  • .gitignore - add opensrc/ to ignore list");
-  console.log("  • tsconfig.json - exclude opensrc/ from compilation");
+  console.log("  • .gitignore - add .opensrc/ to ignore list");
+  console.log("  • tsconfig.json - exclude .opensrc/ from compilation");
   console.log("  • AGENTS.md - add source code reference section\n");
 
   const allowed = await confirm("Allow opensrc to modify these files?");
@@ -71,9 +71,9 @@ async function checkFileModificationPermission(
   await setFileModificationPermission(allowed, cwd);
 
   if (allowed) {
-    console.log("✓ Permission granted - saved to opensrc/settings.json\n");
+    console.log("✓ Permission granted - saved to ..opensrc/settings.json\n");
   } else {
-    console.log("✗ Permission denied - saved to opensrc/settings.json\n");
+    console.log("✗ Permission denied - saved to ..opensrc/settings.json\n");
   }
 
   return allowed;
@@ -144,7 +144,7 @@ async function fetchRepoInput(spec: string, cwd: string): Promise<FetchResult> {
     const result = await fetchRepoSource(resolved, cwd);
 
     if (result.success) {
-      console.log(`  ✓ Saved to opensrc/${result.path}`);
+      console.log(`  ✓ Saved to .opensrc/${result.path}`);
       if (result.error) {
         console.log(`  ⚠ ${result.error}`);
       }
@@ -238,7 +238,7 @@ async function fetchPackageInput(
     const result = await fetchSource(resolved, cwd);
 
     if (result.success) {
-      console.log(`  ✓ Saved to opensrc/${result.path}`);
+      console.log(`  ✓ Saved to .opensrc/${result.path}`);
       if (result.error) {
         console.log(`  ⚠ ${result.error}`);
       }
@@ -337,12 +337,12 @@ export async function fetchCommand(
   if (canModifyFiles) {
     const gitignoreUpdated = await ensureGitignore(cwd);
     if (gitignoreUpdated) {
-      console.log("✓ Added opensrc/ to .gitignore");
+      console.log("✓ Added .opensrc/ to .gitignore");
     }
 
     const tsconfigUpdated = await ensureTsconfigExclude(cwd);
     if (tsconfigUpdated) {
-      console.log("✓ Added opensrc/ to tsconfig.json exclude");
+      console.log("✓ Added .opensrc/ to tsconfig.json exclude");
     }
   }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -74,7 +74,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
       });
 
       console.log(`  ${source.name}@${source.version}`);
-      console.log(`    Path: opensrc/${source.path}`);
+      console.log(`    Path: .opensrc/${source.path}`);
       console.log(`    Fetched: ${formattedDate}`);
       console.log("");
     }
@@ -96,7 +96,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
       });
 
       console.log(`  ${source.name}@${source.version}`);
-      console.log(`    Path: opensrc/${source.path}`);
+      console.log(`    Path: .opensrc/${source.path}`);
       console.log(`    Fetched: ${formattedDate}`);
       console.log("");
     }

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -12,7 +12,7 @@ import {
 
 const TEST_DIR = join(process.cwd(), ".test-agents");
 const AGENTS_FILE = join(TEST_DIR, "AGENTS.md");
-const OPENSRC_DIR = join(TEST_DIR, "opensrc");
+const OPENSRC_DIR = join(TEST_DIR, ".opensrc");
 const SOURCES_FILE = join(OPENSRC_DIR, "sources.json");
 
 const SECTION_MARKER = "<!-- opensrc:start -->";

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -4,7 +4,7 @@ import { existsSync } from "fs";
 import type { Registry } from "../types.js";
 
 const AGENTS_FILE = "AGENTS.md";
-const OPENSRC_DIR = "opensrc";
+const OPENSRC_DIR = ".opensrc";
 const SOURCES_FILE = "sources.json";
 const SECTION_START = "## Source Code Reference";
 const SECTION_MARKER = "<!-- opensrc:start -->";
@@ -18,9 +18,9 @@ function getSectionContent(): string {
 
 ${SECTION_START}
 
-Source code for dependencies is available in \`opensrc/\` for deeper understanding of implementation details.
+Source code for dependencies is available in \`.opensrc/\` for deeper understanding of implementation details.
 
-See \`opensrc/sources.json\` for the list of available packages and their versions.
+See \`.opensrc/sources.json\` for the list of available packages and their versions.
 
 Use this source code when you need to understand how a package works internally, not just its types/interface.
 

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -19,7 +19,7 @@ import {
 } from "./git.js";
 
 const TEST_DIR = join(process.cwd(), ".test-git");
-const OPENSRC_DIR = join(TEST_DIR, "opensrc");
+const OPENSRC_DIR = join(TEST_DIR, ".opensrc");
 
 beforeEach(async () => {
   await mkdir(OPENSRC_DIR, { recursive: true });
@@ -33,31 +33,31 @@ afterEach(async () => {
 
 describe("path helpers", () => {
   describe("getOpensrcDir", () => {
-    it("returns opensrc directory path", () => {
-      expect(getOpensrcDir("/project")).toBe("/project/opensrc");
+    it("returns .opensrc directory path", () => {
+      expect(getOpensrcDir("/project")).toBe("/project/.opensrc");
     });
 
     it("uses cwd by default", () => {
-      expect(getOpensrcDir()).toBe(join(process.cwd(), "opensrc"));
+      expect(getOpensrcDir()).toBe(join(process.cwd(), ".opensrc"));
     });
   });
 
   describe("getReposDir", () => {
     it("returns repos directory path", () => {
-      expect(getReposDir("/project")).toBe("/project/opensrc/repos");
+      expect(getReposDir("/project")).toBe("/project/.opensrc/repos");
     });
   });
 
   describe("getRepoPath", () => {
     it("returns full path for repo", () => {
       expect(getRepoPath("github.com/vercel/ai", "/project")).toBe(
-        "/project/opensrc/repos/github.com/vercel/ai",
+        "/project/.opensrc/repos/github.com/vercel/ai",
       );
     });
 
     it("handles different hosts", () => {
       expect(getRepoPath("gitlab.com/owner/repo", "/project")).toBe(
-        "/project/opensrc/repos/gitlab.com/owner/repo",
+        "/project/.opensrc/repos/gitlab.com/owner/repo",
       );
     });
   });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -9,7 +9,7 @@ import type {
   Registry,
 } from "../types.js";
 
-const OPENSRC_DIR = "opensrc";
+const OPENSRC_DIR = ".opensrc";
 const REPOS_DIR = "repos";
 const SOURCES_FILE = "sources.json";
 

--- a/src/lib/gitignore.ts
+++ b/src/lib/gitignore.ts
@@ -2,8 +2,11 @@ import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 
-const OPENSRC_ENTRY = "opensrc/";
+const OPENSRC_ENTRY = ".opensrc/";
 const MARKER_COMMENT = "# opensrc - source code for packages";
+
+// Legacy entries to detect (before the rename to .opensrc)
+const LEGACY_ENTRIES = ["opensrc/", "opensrc"];
 
 /**
  * Check if .gitignore already has .opensrc/ entry
@@ -23,7 +26,11 @@ export async function hasOpensrcEntry(
 
     return lines.some((line) => {
       const trimmed = line.trim();
-      return trimmed === OPENSRC_ENTRY || trimmed === "opensrc";
+      return (
+        trimmed === OPENSRC_ENTRY ||
+        trimmed === ".opensrc" ||
+        LEGACY_ENTRIES.includes(trimmed)
+      );
     });
   } catch {
     return false;
@@ -83,7 +90,8 @@ export async function removeFromGitignore(
       const trimmed = line.trim();
       return (
         trimmed !== OPENSRC_ENTRY &&
-        trimmed !== "opensrc" &&
+        trimmed !== ".opensrc" &&
+        !LEGACY_ENTRIES.includes(trimmed) &&
         trimmed !== MARKER_COMMENT
       );
     });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 
-const OPENSRC_DIR = "opensrc";
+const OPENSRC_DIR = ".opensrc";
 const SETTINGS_FILE = "settings.json";
 
 export interface OpensrcSettings {

--- a/src/lib/tsconfig.test.ts
+++ b/src/lib/tsconfig.test.ts
@@ -42,7 +42,7 @@ describe("hasOpensrcExclude", () => {
     expect(await hasOpensrcExclude(TEST_DIR)).toBe(false);
   });
 
-  it("returns false if exclude array does not contain opensrc", async () => {
+  it("returns false if exclude array does not contain .opensrc", async () => {
     await writeFile(
       TSCONFIG_PATH,
       JSON.stringify({ exclude: ["node_modules", "dist"] }),
@@ -50,26 +50,34 @@ describe("hasOpensrcExclude", () => {
     expect(await hasOpensrcExclude(TEST_DIR)).toBe(false);
   });
 
-  it("returns true if exclude contains opensrc", async () => {
+  it("returns true if exclude contains .opensrc", async () => {
+    await writeFile(
+      TSCONFIG_PATH,
+      JSON.stringify({ exclude: ["node_modules", ".opensrc"] }),
+    );
+    expect(await hasOpensrcExclude(TEST_DIR)).toBe(true);
+  });
+
+  it("returns true if exclude contains .opensrc/", async () => {
+    await writeFile(
+      TSCONFIG_PATH,
+      JSON.stringify({ exclude: ["node_modules", ".opensrc/"] }),
+    );
+    expect(await hasOpensrcExclude(TEST_DIR)).toBe(true);
+  });
+
+  it("returns true if exclude contains ./.opensrc", async () => {
+    await writeFile(
+      TSCONFIG_PATH,
+      JSON.stringify({ exclude: ["node_modules", "./.opensrc"] }),
+    );
+    expect(await hasOpensrcExclude(TEST_DIR)).toBe(true);
+  });
+
+  it("returns true if exclude contains legacy opensrc", async () => {
     await writeFile(
       TSCONFIG_PATH,
       JSON.stringify({ exclude: ["node_modules", "opensrc"] }),
-    );
-    expect(await hasOpensrcExclude(TEST_DIR)).toBe(true);
-  });
-
-  it("returns true if exclude contains opensrc/", async () => {
-    await writeFile(
-      TSCONFIG_PATH,
-      JSON.stringify({ exclude: ["node_modules", "opensrc/"] }),
-    );
-    expect(await hasOpensrcExclude(TEST_DIR)).toBe(true);
-  });
-
-  it("returns true if exclude contains ./opensrc", async () => {
-    await writeFile(
-      TSCONFIG_PATH,
-      JSON.stringify({ exclude: ["node_modules", "./opensrc"] }),
     );
     expect(await hasOpensrcExclude(TEST_DIR)).toBe(true);
   });
@@ -86,14 +94,21 @@ describe("ensureTsconfigExclude", () => {
     expect(result).toBe(false);
   });
 
-  it("returns false if opensrc already in exclude", async () => {
+  it("returns false if .opensrc already in exclude", async () => {
+    await writeFile(TSCONFIG_PATH, JSON.stringify({ exclude: [".opensrc"] }));
+
+    const result = await ensureTsconfigExclude(TEST_DIR);
+    expect(result).toBe(false);
+  });
+
+  it("returns false if legacy opensrc already in exclude", async () => {
     await writeFile(TSCONFIG_PATH, JSON.stringify({ exclude: ["opensrc"] }));
 
     const result = await ensureTsconfigExclude(TEST_DIR);
     expect(result).toBe(false);
   });
 
-  it("adds opensrc to existing exclude array", async () => {
+  it("adds .opensrc to existing exclude array", async () => {
     await writeFile(
       TSCONFIG_PATH,
       JSON.stringify({ exclude: ["node_modules", "dist"] }),
@@ -103,7 +118,7 @@ describe("ensureTsconfigExclude", () => {
     expect(result).toBe(true);
 
     const content = JSON.parse(await readFile(TSCONFIG_PATH, "utf-8"));
-    expect(content.exclude).toContain("opensrc");
+    expect(content.exclude).toContain(".opensrc");
     expect(content.exclude).toContain("node_modules");
     expect(content.exclude).toContain("dist");
   });
@@ -118,7 +133,7 @@ describe("ensureTsconfigExclude", () => {
     expect(result).toBe(true);
 
     const content = JSON.parse(await readFile(TSCONFIG_PATH, "utf-8"));
-    expect(content.exclude).toEqual(["opensrc"]);
+    expect(content.exclude).toEqual([".opensrc"]);
     expect(content.compilerOptions.strict).toBe(true);
   });
 
@@ -138,7 +153,7 @@ describe("ensureTsconfigExclude", () => {
     const content = JSON.parse(await readFile(TSCONFIG_PATH, "utf-8"));
     expect(content.compilerOptions).toEqual(originalConfig.compilerOptions);
     expect(content.include).toEqual(originalConfig.include);
-    expect(content.exclude).toContain("opensrc");
+    expect(content.exclude).toContain(".opensrc");
   });
 
   it("uses 2-space indentation", async () => {

--- a/src/lib/tsconfig.ts
+++ b/src/lib/tsconfig.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 
-const OPENSRC_DIR = "opensrc";
+const OPENSRC_DIR = ".opensrc";
 
 interface TsConfig {
   exclude?: string[];
@@ -40,7 +40,11 @@ export async function hasOpensrcExclude(
       (entry) =>
         entry === OPENSRC_DIR ||
         entry === `${OPENSRC_DIR}/` ||
-        entry === `./${OPENSRC_DIR}`,
+        entry === `./${OPENSRC_DIR}` ||
+        // Legacy entries (before the rename to .opensrc)
+        entry === "opensrc" ||
+        entry === "opensrc/" ||
+        entry === "./opensrc",
     );
   } catch {
     return false;


### PR DESCRIPTION
## Summary

The `opensrc/` directory stores cloned source code that should not be committed to version control. Using a visible, non-dotfile directory name means it shows up in `git status`, file explorers, and directory listings by default, requiring users to manually add it to `.gitignore`.

This PR renames the output directory from `opensrc/` to `.opensrc/`, following the convention used by other tools (`.next/`, `.turbo/`, `.cache/`, `.trigger/`, etc.) where generated/ephemeral directories use dotfile names.

### Changes

- Renamed the output directory constant from `"opensrc"` to `".opensrc"` across all source files
- Updated all console output messages, README, and AGENTS.md template to reference `.opensrc/`
- Added backward compatibility: `.gitignore` and `tsconfig.json` detection recognizes both the legacy `opensrc/` and new `.opensrc/` entries to avoid duplicates when upgrading
- Updated all existing tests and added new tests for legacy entry detection

### Why

- Dotfile directories are hidden by default in Unix file explorers and `ls` output
- Consistent with ecosystem conventions (`.next/`, `.turbo/`, `.cache/`, `.trigger/`, etc.)
- Reduces noise in `git status` for projects that haven't opted into file modifications yet
- Being a dotfile makes it immediately obvious this is a tool-generated directory, not project source code