### PR TITLE
Command to update all repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,21 @@ GitHub repos are stored as `opensrc/owner--repo/`.
 # List fetched sources
 opensrc list
 
+# Update all fetched sources
+opensrc update
+
+# Update only repos or a specific registry
+opensrc update --repos
+opensrc update --pypi
+
 # Remove a source (package or repo)
 opensrc remove zod
 opensrc remove owner--repo
 ```
+
+`opensrc update` follows the same behavior as re-running `opensrc <package>` or
+`opensrc <owner>/<repo>`: packages resolve to installed/latest versions, and
+repos reuse the stored ref.
 
 ### File Modifications
 

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { buildUpdateSpecs } from "./update.js";
+import type { PackageEntry, RepoEntry } from "../lib/agents.js";
+
+const sources = {
+  packages: [
+    {
+      name: "zod",
+      version: "3.22.0",
+      registry: "npm",
+      path: "zod",
+      fetchedAt: "2024-01-01T00:00:00.000Z",
+    },
+    {
+      name: "requests",
+      version: "2.31.0",
+      registry: "pypi",
+      path: "requests",
+      fetchedAt: "2024-01-01T00:00:00.000Z",
+    },
+    {
+      name: "serde",
+      version: "1.0.0",
+      registry: "crates",
+      path: "serde",
+      fetchedAt: "2024-01-01T00:00:00.000Z",
+    },
+  ],
+  repos: [
+    {
+      name: "github.com/vercel/ai",
+      version: "main",
+      path: "repos/github.com/vercel/ai",
+      fetchedAt: "2024-01-01T00:00:00.000Z",
+    },
+    {
+      name: "example.com/foo/bar",
+      version: "HEAD",
+      path: "repos/example.com/foo/bar",
+      fetchedAt: "2024-01-01T00:00:00.000Z",
+    },
+  ],
+} satisfies { packages: PackageEntry[]; repos: RepoEntry[] };
+
+describe("buildUpdateSpecs", () => {
+  it("builds specs for all sources by default", () => {
+    const { specs, packageCount, repoCount } = buildUpdateSpecs(sources);
+
+    expect(packageCount).toBe(3);
+    expect(repoCount).toBe(2);
+    expect(specs).toEqual([
+      "npm:zod",
+      "pypi:requests",
+      "crates:serde",
+      "https://github.com/vercel/ai#main",
+      "https://example.com/foo/bar",
+    ]);
+  });
+
+  it("filters by registry", () => {
+    const { specs, packageCount, repoCount } = buildUpdateSpecs(sources, {
+      registry: "pypi",
+    });
+
+    expect(packageCount).toBe(1);
+    expect(repoCount).toBe(0);
+    expect(specs).toEqual(["pypi:requests"]);
+  });
+
+  it("updates only packages when requested", () => {
+    const { specs, packageCount, repoCount } = buildUpdateSpecs(sources, {
+      packages: true,
+      repos: false,
+    });
+
+    expect(packageCount).toBe(3);
+    expect(repoCount).toBe(0);
+    expect(specs).toEqual(["npm:zod", "pypi:requests", "crates:serde"]);
+  });
+
+  it("updates only repos when requested", () => {
+    const { specs, packageCount, repoCount } = buildUpdateSpecs(sources, {
+      packages: false,
+      repos: true,
+    });
+
+    expect(packageCount).toBe(0);
+    expect(repoCount).toBe(2);
+    expect(specs).toEqual([
+      "https://github.com/vercel/ai#main",
+      "https://example.com/foo/bar",
+    ]);
+  });
+});

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,123 @@
+import { listSources } from "../lib/git.js";
+import type { Registry } from "../types.js";
+import { fetchCommand } from "./fetch.js";
+
+export interface UpdateOptions {
+  cwd?: string;
+  /** Only update packages (all registries) */
+  packages?: boolean;
+  /** Only update repos */
+  repos?: boolean;
+  /** Only update specific registry */
+  registry?: Registry;
+  /** Override file modification permission */
+  allowModifications?: boolean;
+}
+
+type Sources = Awaited<ReturnType<typeof listSources>>;
+
+function shouldUpdatePackages(options: UpdateOptions): boolean {
+  return options.packages || (!options.packages && !options.repos);
+}
+
+function shouldUpdateRepos(options: UpdateOptions): boolean {
+  return (
+    options.repos || (!options.packages && !options.repos && !options.registry)
+  );
+}
+
+function buildRepoSpec(name: string, version: string): string {
+  const base = `https://${name}`;
+  if (!version || version === "HEAD") {
+    return base;
+  }
+  return `${base}#${version}`;
+}
+
+export function buildUpdateSpecs(
+  sources: Sources,
+  options: UpdateOptions = {},
+): { specs: string[]; packageCount: number; repoCount: number } {
+  const updatePackages = shouldUpdatePackages(options);
+  const updateRepos = shouldUpdateRepos(options);
+
+  let packages = updatePackages ? sources.packages : [];
+  if (options.registry) {
+    packages = packages.filter((p) => p.registry === options.registry);
+  }
+
+  const repos = updateRepos ? sources.repos : [];
+
+  const specs: string[] = [];
+  const seen = new Set<string>();
+
+  for (const pkg of packages) {
+    const spec = `${pkg.registry}:${pkg.name}`;
+    if (!seen.has(spec)) {
+      specs.push(spec);
+      seen.add(spec);
+    }
+  }
+
+  for (const repo of repos) {
+    const spec = buildRepoSpec(repo.name, repo.version);
+    if (!seen.has(spec)) {
+      specs.push(spec);
+      seen.add(spec);
+    }
+  }
+
+  return { specs, packageCount: packages.length, repoCount: repos.length };
+}
+
+/**
+ * Update all fetched packages and/or repositories
+ */
+export async function updateCommand(
+  options: UpdateOptions = {},
+): Promise<void> {
+  const cwd = options.cwd || process.cwd();
+  const sources = await listSources(cwd);
+  const totalCount = sources.packages.length + sources.repos.length;
+
+  if (totalCount === 0) {
+    console.log("No sources fetched yet.");
+    console.log(
+      "\nUse `opensrc <package>` to fetch source code for a package.",
+    );
+    console.log("Use `opensrc <owner>/<repo>` to fetch a GitHub repository.");
+    console.log("\nSupported registries:");
+    console.log("  • npm:      opensrc zod, opensrc npm:react");
+    console.log("  • PyPI:     opensrc pypi:requests");
+    console.log("  • crates:   opensrc crates:serde");
+    return;
+  }
+
+  const { specs, packageCount, repoCount } = buildUpdateSpecs(sources, options);
+
+  if (specs.length === 0) {
+    const updatePackages = shouldUpdatePackages(options);
+    const updateRepos = shouldUpdateRepos(options);
+
+    if (options.registry) {
+      console.log(`No ${options.registry} packages to update.`);
+    } else {
+      if (updatePackages && packageCount === 0) {
+        console.log("No packages to update");
+      }
+      if (updateRepos && repoCount === 0) {
+        console.log("No repos to update");
+      }
+    }
+
+    console.log("\nNothing to update.");
+    return;
+  }
+
+  console.log(`Updating ${specs.length} source(s)...`);
+
+  await fetchCommand(specs, {
+    cwd,
+    allowModifications: options.allowModifications,
+  });
+}

--- a/src/lib/repo.test.ts
+++ b/src/lib/repo.test.ts
@@ -276,8 +276,10 @@ describe("isRepoSpec", () => {
       expect(isRepoSpec("https://bitbucket.org/owner/repo")).toBe(true);
     });
 
-    it("non-standard host URLs", () => {
-      expect(isRepoSpec("https://example.com/owner/repo")).toBe(true);
+    it("non-standard host URLs with git signals", () => {
+      expect(isRepoSpec("https://git.example.com/owner/repo")).toBe(true);
+      expect(isRepoSpec("https://example.com/owner/repo.git")).toBe(true);
+      expect(isRepoSpec("https://example.com/owner/repo/tree/main")).toBe(true);
     });
 
     it("host/owner/repo format", () => {
@@ -311,6 +313,10 @@ describe("isRepoSpec", () => {
     it("package names with version", () => {
       expect(isRepoSpec("lodash@4.17.0")).toBe(false);
       expect(isRepoSpec("react@18.2.0")).toBe(false);
+    });
+
+    it("non-standard host URLs without git signals", () => {
+      expect(isRepoSpec("https://example.com/owner/repo")).toBe(false);
     });
   });
 });

--- a/src/lib/repo.test.ts
+++ b/src/lib/repo.test.ts
@@ -276,6 +276,10 @@ describe("isRepoSpec", () => {
       expect(isRepoSpec("https://bitbucket.org/owner/repo")).toBe(true);
     });
 
+    it("non-standard host URLs", () => {
+      expect(isRepoSpec("https://example.com/owner/repo")).toBe(true);
+    });
+
     it("host/owner/repo format", () => {
       expect(isRepoSpec("github.com/vercel/ai")).toBe(true);
     });

--- a/src/lib/repo.test.ts
+++ b/src/lib/repo.test.ts
@@ -84,6 +84,26 @@ describe("parseRepoSpec", () => {
       });
     });
 
+    it("parses https://github.com/owner/repo#ref", () => {
+      const result = parseRepoSpec("https://github.com/vercel/ai#canary");
+      expect(result).toEqual({
+        host: "github.com",
+        owner: "vercel",
+        repo: "ai",
+        ref: "canary",
+      });
+    });
+
+    it("parses https://github.com/owner/repo#ref/with/slash", () => {
+      const result = parseRepoSpec("https://github.com/vercel/ai#feature/foo");
+      expect(result).toEqual({
+        host: "github.com",
+        owner: "vercel",
+        repo: "ai",
+        ref: "feature/foo",
+      });
+    });
+
     it("parses https://github.com/owner/repo.git", () => {
       const result = parseRepoSpec("https://github.com/vercel/ai.git");
       expect(result).toEqual({

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -127,9 +127,17 @@ export function isRepoSpec(spec: string): boolean {
     return true;
   }
 
-  // Git host URL
-  if (trimmed.match(/^https?:\/\/(github\.com|gitlab\.com|bitbucket\.org)\//)) {
-    return true;
+  // Git host URL (any host)
+  if (trimmed.match(/^https?:\/\//)) {
+    try {
+      const url = new URL(trimmed);
+      const parts = url.pathname.split("/").filter(Boolean);
+      if (parts.length >= 2) {
+        return true;
+      }
+    } catch {
+      // Fall through
+    }
   }
 
   // host/owner/repo format

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -14,6 +14,7 @@ const DEFAULT_HOST = "github.com";
  * - owner/repo@ref
  * - owner/repo#ref
  * - https://github.com/owner/repo
+ * - https://github.com/owner/repo#ref
  * - https://gitlab.com/owner/repo
  * - https://github.com/owner/repo/tree/branch
  * - github.com/owner/repo
@@ -53,11 +54,14 @@ export function parseRepoSpec(spec: string): RepoSpec | null {
         repo = repo.slice(0, -4);
       }
 
-      // Handle /tree/branch or /blob/branch URLs
-      if (
+      const hashRef = url.hash ? decodeURIComponent(url.hash.slice(1)) : "";
+      if (hashRef) {
+        ref = hashRef;
+      } else if (
         pathParts.length >= 4 &&
         (pathParts[2] === "tree" || pathParts[2] === "blob")
       ) {
+        // Handle /tree/branch or /blob/branch URLs
         ref = pathParts[3];
       }
 


### PR DESCRIPTION
If you’ve fetched many packages/repos over time, you currently have to re-run `opensrc <pkg>` or `opensrc <owner/repo>` for each one. `opensrc update` refreshes everything in one command while keeping pinned repo refs stable.

Concept
  - Add `opensrc update` to refresh all previously fetched sources listed in `opensrc/sources.json`, matching the existing CLI style (list, remove, clean).
  - Preserve repo refs when updating, including refs encoded as URL hashes.

Expected usage
```
  # Update everything already fetched
  opensrc update

  # Update only repos or specific registries
  opensrc update --repos
  opensrc update --pypi
  opensrc update --crates
```

Behavior
  - Packages: re-run with registry + name (resolves to installed/latest versions, same as re-running `opensrc <package>`).
  - Repos: re-run with stored ref (branch/tag/commit) to avoid drifting.

Methodology
  - New update command builds specs from `sources.json` and reuses `fetchCommand` for consistent logging/permissions.
  - Repo parser now reads URL hash refs (`https://host/owner/repo#ref`) to preserve stored refs.

Coverage
  - Added unit tests for update spec building and URL hash ref parsing.
  - Ran `npm test`, `npm run type-check`, and `npm run format:check`.