### PR TITLE
feat: output local paths after fetching repos

### DIFF
--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   detectInputType,
   parsePackageSpec,
@@ -363,6 +364,17 @@ export async function fetchCommand(
   const failed = results.filter((r) => !r.success).length;
 
   console.log(`\nDone: ${successful} succeeded, ${failed} failed`);
+
+  // Output local paths for successful fetches (helpful for AI coding agents)
+  const successfulResults = results.filter((r) => r.success);
+  if (successfulResults.length > 0) {
+    const resolvedCwd = path.resolve(cwd);
+    console.log(`\nLocal paths:`);
+    for (const result of successfulResults) {
+      const absolutePath = path.join(resolvedCwd, "opensrc", result.path);
+      console.log(`  ${result.package}@${result.version}: ${absolutePath}`);
+    }
+  }
 
   // Update sources.json with all fetched sources
   if (successful > 0) {


### PR DESCRIPTION
## Summary

After fetching packages/repos, the CLI now outputs the absolute local paths to the fetched source code. This helps AI coding agents know exactly where to find the code on the local filesystem.

## Output Example

```
Fetching picocolors from npm...
  → No installed version found, using latest
  → Resolving repository...
  → Found: https://github.com/alexeyraspopov/picocolors
  → Cloning at v1.1.1...
  ✓ Saved to opensrc/repos/github.com/alexeyraspopov/picocolors

Done: 1 succeeded, 0 failed

Local paths:
  picocolors@1.1.1: /private/tmp/opensrc-test/opensrc/repos/github.com/alexeyraspopov/picocolors
```

## Motivation

From issue #7 - AI coding agents use `opensrc` to fetch source code for deeper context, but after fetching they don't know where the code is located locally. This change adds a clear summary of absolute paths at the end of the fetch output.

## Changes

- Added `path` import at the top of `src/commands/fetch.ts`
- Added a "Local paths" section after the summary that lists all successfully fetched packages with their absolute paths

## Testing

- All 195 existing tests pass
- Manually verified output format works correctly

Closes #7