### PR TITLE
feat: use package-manager-detector for AGENTS.md runner commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,5 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  },
-  "packageManager": "pnpm@10.21.0+sha512.da3337267e400fdd3d479a6c68079ac6db01d8ca4f67572083e722775a796788a7a9956613749e000fac20d424b594f7a791a5f4e2e13581c5ef947f26968a40"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "commander": "^12.1.0",
+    "package-manager-detector": "^1.6.0",
     "simple-git": "^3.27.0"
   },
   "devDependencies": {
@@ -46,5 +47,6 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.21.0+sha512.da3337267e400fdd3d479a6c68079ac6db01d8ca4f67572083e722775a796788a7a9956613749e000fac20d424b594f7a791a5f4e2e13581c5ef947f26968a40"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      package-manager-detector:
+        specifier: ^1.6.0
+        version: 1.6.0
       simple-git:
         specifier: ^3.27.0
         version: 3.30.0
@@ -427,6 +430,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -852,6 +858,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   obug@2.1.1: {}
+
+  package-manager-detector@1.6.0: {}
 
   pathe@2.0.3: {}
 

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -69,7 +69,7 @@ describe("ensureAgentsMd", () => {
     const content = await readFile(AGENTS_FILE, "utf-8");
     expect(content).toContain("Existing content here.");
     expect(content).toContain(SECTION_MARKER);
-    expect(content).toContain("npx opensrc");
+    expect(content).toContain("opensrc <package>");
   });
 
   it("returns false if section already exists and is up to date", async () => {


### PR DESCRIPTION
Detect the project's package manager (npm, pnpm, yarn, bun) and use the appropriate runner command in AGENTS.md instructions instead of always hardcoding `npx`. For example, pnpm projects now get `pnpm dlx opensrc` and bun projects get `bun x opensrc`. Falls back to `npx` if detection fails.

Closes #16