### PR TITLE
support private repos via OPENSRC_GITHUB_TOKEN and OPENSRC_GITLAB_TOKEN

### DIFF
--- a/opensrc/src/lib/git.ts
+++ b/opensrc/src/lib/git.ts
@@ -1,0 +1,540 @@
+import { simpleGit, SimpleGit } from "simple-git";
+import { rm, mkdir, readFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import type {
+  ResolvedPackage,
+  ResolvedRepo,
+  FetchResult,
+  Registry,
+} from "../types.js";
+
+const OPENSRC_DIR = "opensrc";
+const REPOS_DIR = "repos";
+const SOURCES_FILE = "sources.json";
+
+/**
+ * Get the opensrc directory path
+ */
+export function getOpensrcDir(cwd: string = process.cwd()): string {
+  return join(cwd, OPENSRC_DIR);
+}
+
+/**
+ * Get the repos directory path
+ */
+export function getReposDir(cwd: string = process.cwd()): string {
+  return join(getOpensrcDir(cwd), REPOS_DIR);
+}
+
+/**
+ * Extract host/owner/repo from a git URL
+ */
+export function parseRepoUrl(
+  url: string,
+): { host: string; owner: string; repo: string } | null {
+  // Handle HTTPS URLs: https://github.com/owner/repo
+  const httpsMatch = url.match(/https?:\/\/([^/]+)\/([^/]+)\/([^/]+)/);
+  if (httpsMatch) {
+    return {
+      host: httpsMatch[1],
+      owner: httpsMatch[2],
+      repo: httpsMatch[3].replace(/\.git$/, ""),
+    };
+  }
+
+  // Handle SSH URLs: git@github.com:owner/repo.git
+  const sshMatch = url.match(/git@([^:]+):([^/]+)\/(.+)/);
+  if (sshMatch) {
+    return {
+      host: sshMatch[1],
+      owner: sshMatch[2],
+      repo: sshMatch[3].replace(/\.git$/, ""),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Get the path where a repo's source will be stored
+ */
+export function getRepoPath(
+  displayName: string,
+  cwd: string = process.cwd(),
+): string {
+  return join(getReposDir(cwd), displayName);
+}
+
+/**
+ * Get the relative path for a repo (for sources.json)
+ */
+export function getRepoRelativePath(displayName: string): string {
+  return `${REPOS_DIR}/${displayName}`;
+}
+
+/**
+ * Get repo display name from URL
+ */
+export function getRepoDisplayName(repoUrl: string): string | null {
+  const parsed = parseRepoUrl(repoUrl);
+  if (!parsed) return null;
+  return `${parsed.host}/${parsed.owner}/${parsed.repo}`;
+}
+
+interface PackageEntry {
+  name: string;
+  version: string;
+  registry: Registry;
+  path: string;
+  fetchedAt: string;
+}
+
+interface RepoEntry {
+  name: string;
+  version: string;
+  path: string;
+  fetchedAt: string;
+}
+
+/**
+ * Read the sources.json file
+ */
+async function readSourcesJson(cwd: string): Promise<{
+  packages?: PackageEntry[];
+  repos?: RepoEntry[];
+} | null> {
+  const sourcesPath = join(getOpensrcDir(cwd), SOURCES_FILE);
+
+  if (!existsSync(sourcesPath)) {
+    return null;
+  }
+
+  try {
+    const content = await readFile(sourcesPath, "utf-8");
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a repo source already exists
+ */
+export function repoExists(
+  displayName: string,
+  cwd: string = process.cwd(),
+): boolean {
+  return existsSync(getRepoPath(displayName, cwd));
+}
+
+/**
+ * Check if a package's repo already exists
+ */
+export function packageRepoExists(
+  repoUrl: string,
+  cwd: string = process.cwd(),
+): boolean {
+  const displayName = getRepoDisplayName(repoUrl);
+  if (!displayName) return false;
+  return repoExists(displayName, cwd);
+}
+
+/**
+ * Get package info from sources.json
+ */
+export async function getPackageInfo(
+  packageName: string,
+  cwd: string = process.cwd(),
+  registry: Registry = "npm",
+): Promise<PackageEntry | null> {
+  const sources = await readSourcesJson(cwd);
+  if (!sources?.packages) {
+    return null;
+  }
+
+  return (
+    sources.packages.find(
+      (p) => p.name === packageName && p.registry === registry,
+    ) || null
+  );
+}
+
+/**
+ * Get repo info from sources.json
+ */
+export async function getRepoInfo(
+  displayName: string,
+  cwd: string = process.cwd(),
+): Promise<RepoEntry | null> {
+  const sources = await readSourcesJson(cwd);
+  if (!sources?.repos) {
+    return null;
+  }
+
+  return sources.repos.find((r) => r.name === displayName) || null;
+}
+
+/**
+ * Try to clone at a specific tag, with fallbacks
+ */
+async function cloneAtTag(
+  git: SimpleGit,
+  repoUrl: string,
+  targetPath: string,
+  version: string,
+): Promise<{ success: boolean; tag?: string; error?: string }> {
+  const tagsToTry = [`v${version}`, version, `${version}`];
+
+  for (const tag of tagsToTry) {
+    try {
+      await git.clone(repoUrl, targetPath, [
+        "--depth",
+        "1",
+        "--branch",
+        tag,
+        "--single-branch",
+      ]);
+      return { success: true, tag };
+    } catch {
+      continue;
+    }
+  }
+
+  // If no tag worked, clone default branch with a warning
+  try {
+    await git.clone(repoUrl, targetPath, ["--depth", "1"]);
+    return {
+      success: true,
+      tag: "HEAD",
+      error: `Could not find tag for version ${version}, cloned default branch instead`,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: `Failed to clone repository: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * Clone a repository at a specific ref (branch, tag, or commit)
+ */
+async function cloneAtRef(
+  git: SimpleGit,
+  repoUrl: string,
+  targetPath: string,
+  ref: string,
+): Promise<{ success: boolean; ref?: string; error?: string }> {
+  try {
+    await git.clone(repoUrl, targetPath, [
+      "--depth",
+      "1",
+      "--branch",
+      ref,
+      "--single-branch",
+    ]);
+    return { success: true, ref };
+  } catch {
+    // Ref might be a commit or doesn't exist as a branch/tag
+  }
+
+  // Clone default branch
+  try {
+    await git.clone(repoUrl, targetPath, ["--depth", "1"]);
+    return {
+      success: true,
+      ref: "HEAD",
+      error: `Could not find ref "${ref}", cloned default branch instead`,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: `Failed to clone repository: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * Fetch source code for a resolved package
+ */
+export async function fetchSource(
+  resolved: ResolvedPackage,
+  cwd: string = process.cwd(),
+): Promise<FetchResult> {
+  const git = simpleGit();
+
+  // Get repo display name from URL
+  const repoDisplayName = getRepoDisplayName(resolved.repoUrl);
+  if (!repoDisplayName) {
+    return {
+      package: resolved.name,
+      version: resolved.version,
+      path: "",
+      success: false,
+      error: `Could not parse repository URL: ${resolved.repoUrl}`,
+      registry: resolved.registry,
+    };
+  }
+
+  const repoPath = getRepoPath(repoDisplayName, cwd);
+  const reposDir = getReposDir(cwd);
+
+  // Ensure repos directory exists
+  if (!existsSync(reposDir)) {
+    await mkdir(reposDir, { recursive: true });
+  }
+
+  // Remove existing if present (re-fetch at potentially different version)
+  if (existsSync(repoPath)) {
+    await rm(repoPath, { recursive: true, force: true });
+  }
+
+  // Ensure parent directories exist (for host/owner structure)
+  const parentDir = join(repoPath, "..");
+  if (!existsSync(parentDir)) {
+    await mkdir(parentDir, { recursive: true });
+  }
+
+  // Clone the repository
+  const cloneResult = await cloneAtTag(
+    git,
+    resolved.repoUrl,
+    repoPath,
+    resolved.version,
+  );
+
+  if (!cloneResult.success) {
+    return {
+      package: resolved.name,
+      version: resolved.version,
+      path: getRepoRelativePath(repoDisplayName),
+      success: false,
+      error: cloneResult.error,
+      registry: resolved.registry,
+    };
+  }
+
+  // Remove .git directory to save space and avoid confusion
+  const gitDir = join(repoPath, ".git");
+  if (existsSync(gitDir)) {
+    await rm(gitDir, { recursive: true, force: true });
+  }
+
+  // Determine the actual source path (for monorepos, include subdirectory)
+  let relativePath = getRepoRelativePath(repoDisplayName);
+  if (resolved.repoDirectory) {
+    relativePath = `${relativePath}/${resolved.repoDirectory}`;
+  }
+
+  return {
+    package: resolved.name,
+    version: resolved.version,
+    path: relativePath,
+    success: true,
+    error: cloneResult.error,
+    registry: resolved.registry,
+  };
+}
+
+/**
+ * Fetch source code for a resolved repository
+ */
+export async function fetchRepoSource(
+  resolved: ResolvedRepo,
+  cwd: string = process.cwd(),
+): Promise<FetchResult> {
+  const git = simpleGit();
+  const repoPath = getRepoPath(resolved.displayName, cwd);
+  const reposDir = getReposDir(cwd);
+
+  // Ensure repos directory exists
+  if (!existsSync(reposDir)) {
+    await mkdir(reposDir, { recursive: true });
+  }
+
+  // Remove existing if present
+  if (existsSync(repoPath)) {
+    await rm(repoPath, { recursive: true, force: true });
+  }
+
+  // Ensure parent directories exist (for host/owner structure)
+  const parentDir = join(repoPath, "..");
+  if (!existsSync(parentDir)) {
+    await mkdir(parentDir, { recursive: true });
+  }
+
+  // Clone the repository
+  const cloneResult = await cloneAtRef(
+    git,
+    resolved.repoUrl,
+    repoPath,
+    resolved.ref,
+  );
+
+  if (!cloneResult.success) {
+    return {
+      package: resolved.displayName,
+      version: resolved.ref,
+      path: getRepoRelativePath(resolved.displayName),
+      success: false,
+      error: cloneResult.error,
+    };
+  }
+
+  // Remove .git directory to save space and avoid confusion
+  const gitDir = join(repoPath, ".git");
+  if (existsSync(gitDir)) {
+    await rm(gitDir, { recursive: true, force: true });
+  }
+
+  return {
+    package: resolved.displayName,
+    version: resolved.ref,
+    path: getRepoRelativePath(resolved.displayName),
+    success: true,
+    error: cloneResult.error,
+  };
+}
+
+/**
+ * Extract the repo path from a full path (removes any monorepo subdirectory)
+ * e.g., "repos/github.com/owner/repo/packages/sub" -> "repos/github.com/owner/repo"
+ */
+function extractRepoPath(fullPath: string): string {
+  const parts = fullPath.split("/");
+  // repos/host/owner/repo = 4 parts minimum
+  if (parts.length >= 4 && parts[0] === "repos") {
+    return parts.slice(0, 4).join("/");
+  }
+  return fullPath;
+}
+
+/**
+ * Remove source code for a package (removes its repo if no other packages use it)
+ */
+export async function removePackageSource(
+  packageName: string,
+  cwd: string = process.cwd(),
+  registry: Registry = "npm",
+): Promise<{ removed: boolean; repoRemoved: boolean }> {
+  const sources = await readSourcesJson(cwd);
+  if (!sources?.packages) {
+    return { removed: false, repoRemoved: false };
+  }
+
+  const pkg = sources.packages.find(
+    (p) => p.name === packageName && p.registry === registry,
+  );
+  if (!pkg) {
+    return { removed: false, repoRemoved: false };
+  }
+
+  const pkgRepoPath = extractRepoPath(pkg.path);
+
+  // Check if other packages use the same repo
+  const otherPackagesUsingSameRepo = sources.packages.filter(
+    (p) =>
+      extractRepoPath(p.path) === pkgRepoPath &&
+      !(p.name === packageName && p.registry === registry),
+  );
+
+  let repoRemoved = false;
+
+  // Only remove the repo if no other packages use it
+  if (otherPackagesUsingSameRepo.length === 0) {
+    const repoPath = join(getOpensrcDir(cwd), pkgRepoPath);
+    if (existsSync(repoPath)) {
+      await rm(repoPath, { recursive: true, force: true });
+      repoRemoved = true;
+
+      // Clean up empty parent directories
+      await cleanupEmptyParentDirs(pkgRepoPath, cwd);
+    }
+  }
+
+  return { removed: true, repoRemoved };
+}
+
+/**
+ * Remove source code for a repo
+ */
+export async function removeRepoSource(
+  displayName: string,
+  cwd: string = process.cwd(),
+): Promise<boolean> {
+  const repoPath = getRepoPath(displayName, cwd);
+
+  if (!existsSync(repoPath)) {
+    return false;
+  }
+
+  await rm(repoPath, { recursive: true, force: true });
+
+  // Clean up empty parent directories
+  await cleanupEmptyParentDirs(getRepoRelativePath(displayName), cwd);
+
+  return true;
+}
+
+/**
+ * Clean up empty parent directories after removing a repo
+ */
+async function cleanupEmptyParentDirs(
+  relativePath: string,
+  cwd: string,
+): Promise<void> {
+  const parts = relativePath.split("/");
+  if (parts.length < 4) return; // repos/host/owner/repo - need at least 4 parts
+
+  const { readdir } = await import("fs/promises");
+  const opensrcDir = getOpensrcDir(cwd);
+
+  // Try to clean up owner directory (repos/host/owner)
+  const ownerDir = join(opensrcDir, parts[0], parts[1], parts[2]);
+  try {
+    const ownerContents = await readdir(ownerDir);
+    if (ownerContents.length === 0) {
+      await rm(ownerDir, { recursive: true, force: true });
+    }
+  } catch {
+    // Ignore errors
+  }
+
+  // Try to clean up host directory (repos/host)
+  const hostDir = join(opensrcDir, parts[0], parts[1]);
+  try {
+    const hostContents = await readdir(hostDir);
+    if (hostContents.length === 0) {
+      await rm(hostDir, { recursive: true, force: true });
+    }
+  } catch {
+    // Ignore errors
+  }
+}
+
+/**
+ * @deprecated Use removePackageSource instead
+ */
+export async function removeSource(
+  packageName: string,
+  cwd: string = process.cwd(),
+): Promise<boolean> {
+  const result = await removePackageSource(packageName, cwd, "npm");
+  return result.removed;
+}
+
+/**
+ * List all fetched sources from sources.json
+ */
+export async function listSources(cwd: string = process.cwd()): Promise<{
+  packages: PackageEntry[];
+  repos: RepoEntry[];
+}> {
+  const sources = await readSourcesJson(cwd);
+
+  return {
+    packages: sources?.packages || [],
+    repos: sources?.repos || [],
+  };
+}

--- a/opensrc/src/lib/git.ts
+++ b/opensrc/src/lib/git.ts
@@ -14,6 +14,13 @@ const REPOS_DIR = "repos";
 const SOURCES_FILE = "sources.json";
 
 /**
+ * Strip credentials from URLs in error messages to prevent token leakage.
+ */
+export function sanitizeError(message: string): string {
+  return message.replace(/https?:\/\/[^@\s]+@/g, "https://***@");
+}
+
+/**
  * Get the opensrc directory path
  */
 export function getOpensrcDir(cwd: string = process.cwd()): string {
@@ -212,7 +219,7 @@ async function cloneAtTag(
   } catch (err) {
     return {
       success: false,
-      error: `Failed to clone repository: ${err instanceof Error ? err.message : String(err)}`,
+      error: sanitizeError(`Failed to clone repository: ${err instanceof Error ? err.message : String(err)}`),
     };
   }
 }
@@ -250,7 +257,7 @@ async function cloneAtRef(
   } catch (err) {
     return {
       success: false,
-      error: `Failed to clone repository: ${err instanceof Error ? err.message : String(err)}`,
+      error: sanitizeError(`Failed to clone repository: ${err instanceof Error ? err.message : String(err)}`),
     };
   }
 }
@@ -296,10 +303,11 @@ export async function fetchSource(
     await mkdir(parentDir, { recursive: true });
   }
 
-  // Clone the repository
+  // Clone the repository (prefer authenticated URL for private repos)
+  const cloneUrl = resolved.cloneUrl || resolved.repoUrl;
   const cloneResult = await cloneAtTag(
     git,
-    resolved.repoUrl,
+    cloneUrl,
     repoPath,
     resolved.version,
   );
@@ -364,13 +372,9 @@ export async function fetchRepoSource(
     await mkdir(parentDir, { recursive: true });
   }
 
-  // Clone the repository
-  const cloneResult = await cloneAtRef(
-    git,
-    resolved.repoUrl,
-    repoPath,
-    resolved.ref,
-  );
+  // Clone the repository (prefer authenticated URL for private repos)
+  const cloneUrl = resolved.cloneUrl || resolved.repoUrl;
+  const cloneResult = await cloneAtRef(git, cloneUrl, repoPath, resolved.ref);
 
   if (!cloneResult.success) {
     return {

--- a/opensrc/src/lib/repo.ts
+++ b/opensrc/src/lib/repo.ts
@@ -1,0 +1,314 @@
+import type { RepoSpec, ResolvedRepo } from "../types.js";
+
+// Supported git hosts
+const SUPPORTED_HOSTS = ["github.com", "gitlab.com", "bitbucket.org"];
+const DEFAULT_HOST = "github.com";
+
+/**
+ * Parse a repository specification into host, owner and repo
+ * Supports:
+ * - github:owner/repo
+ * - github:owner/repo@ref
+ * - gitlab:owner/repo
+ * - owner/repo (defaults to github.com)
+ * - owner/repo@ref
+ * - owner/repo#ref
+ * - https://github.com/owner/repo
+ * - https://gitlab.com/owner/repo
+ * - https://github.com/owner/repo/tree/branch
+ * - github.com/owner/repo
+ */
+export function parseRepoSpec(spec: string): RepoSpec | null {
+  let input = spec.trim();
+  let ref: string | undefined;
+  let host: string = DEFAULT_HOST;
+
+  // Handle shorthand prefixes: github:, gitlab:, bitbucket:
+  if (input.startsWith("github:")) {
+    host = "github.com";
+    input = input.slice(7);
+  } else if (input.startsWith("gitlab:")) {
+    host = "gitlab.com";
+    input = input.slice(7);
+  } else if (input.startsWith("bitbucket:")) {
+    host = "bitbucket.org";
+    input = input.slice(10);
+  }
+  // Handle full URLs: https://github.com/owner/repo
+  else if (input.match(/^https?:\/\//)) {
+    try {
+      const url = new URL(input);
+      host = url.hostname;
+      const pathParts = url.pathname.slice(1).split("/").filter(Boolean);
+
+      if (pathParts.length < 2) {
+        return null;
+      }
+
+      const owner = pathParts[0];
+      let repo = pathParts[1];
+
+      // Remove .git suffix if present
+      if (repo.endsWith(".git")) {
+        repo = repo.slice(0, -4);
+      }
+
+      // Handle /tree/branch or /blob/branch URLs
+      if (
+        pathParts.length >= 4 &&
+        (pathParts[2] === "tree" || pathParts[2] === "blob")
+      ) {
+        ref = pathParts[3];
+      }
+
+      return { host, owner, repo, ref };
+    } catch {
+      return null;
+    }
+  }
+  // Handle host/owner/repo format: github.com/owner/repo
+  else if (SUPPORTED_HOSTS.some((h) => input.startsWith(`${h}/`))) {
+    const firstSlash = input.indexOf("/");
+    host = input.slice(0, firstSlash);
+    input = input.slice(firstSlash + 1);
+  }
+  // Not a repo format if it starts with @ (scoped npm package)
+  else if (input.startsWith("@")) {
+    return null;
+  }
+  // Must contain exactly one / to be a repo (owner/repo)
+  else if (input.split("/").length !== 2) {
+    return null;
+  }
+
+  // Extract ref from @ or # suffix
+  // owner/repo@v1.0.0 or owner/repo#main
+  const atIndex = input.indexOf("@");
+  const hashIndex = input.indexOf("#");
+
+  if (atIndex > 0) {
+    ref = input.slice(atIndex + 1);
+    input = input.slice(0, atIndex);
+  } else if (hashIndex > 0) {
+    ref = input.slice(hashIndex + 1);
+    input = input.slice(0, hashIndex);
+  }
+
+  // Split into owner/repo
+  const parts = input.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+
+  return {
+    host,
+    owner: parts[0],
+    repo: parts[1],
+    ref,
+  };
+}
+
+/**
+ * Check if a string looks like a repo spec rather than an npm package
+ */
+export function isRepoSpec(spec: string): boolean {
+  const trimmed = spec.trim();
+
+  // Explicit prefix (github:, gitlab:, bitbucket:)
+  if (
+    trimmed.startsWith("github:") ||
+    trimmed.startsWith("gitlab:") ||
+    trimmed.startsWith("bitbucket:")
+  ) {
+    return true;
+  }
+
+  // Git host URL
+  if (trimmed.match(/^https?:\/\/(github\.com|gitlab\.com|bitbucket\.org)\//)) {
+    return true;
+  }
+
+  // host/owner/repo format
+  if (SUPPORTED_HOSTS.some((h) => trimmed.startsWith(`${h}/`))) {
+    return true;
+  }
+
+  // Scoped npm packages start with @
+  if (trimmed.startsWith("@")) {
+    return false;
+  }
+
+  // owner/repo format (must have exactly one /)
+  // But need to distinguish from things that aren't repos
+  const parts = trimmed.split("/");
+  if (parts.length === 2 && parts[0] && parts[1]) {
+    // Extract the repo part (before any @ or #)
+    const repoPart = parts[1].split("@")[0].split("#")[0];
+    // Valid usernames and repos: alphanumeric, hyphens, underscores
+    // Repos can also have dots
+    const validOwner = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/.test(parts[0]);
+    const validRepo = /^[a-zA-Z0-9._-]+$/.test(repoPart);
+    return validOwner && validRepo;
+  }
+
+  return false;
+}
+
+interface GitHubApiResponse {
+  default_branch: string;
+  clone_url: string;
+  html_url: string;
+}
+
+interface GitLabApiResponse {
+  default_branch: string;
+  http_url_to_repo: string;
+  web_url: string;
+}
+
+/**
+ * Resolve a repo spec to full repository information using the appropriate API
+ */
+export async function resolveRepo(spec: RepoSpec): Promise<ResolvedRepo> {
+  const { host, owner, repo, ref } = spec;
+
+  if (host === "github.com") {
+    return resolveGitHubRepo(host, owner, repo, ref);
+  } else if (host === "gitlab.com") {
+    return resolveGitLabRepo(host, owner, repo, ref);
+  } else {
+    // For unsupported hosts, assume default branch is "main"
+    return {
+      host,
+      owner,
+      repo,
+      ref: ref || "main",
+      repoUrl: `https://${host}/${owner}/${repo}`,
+      displayName: `${host}/${owner}/${repo}`,
+    };
+  }
+}
+
+async function resolveGitHubRepo(
+  host: string,
+  owner: string,
+  repo: string,
+  ref?: string,
+): Promise<ResolvedRepo> {
+  const apiUrl = `https://api.github.com/repos/${owner}/${repo}`;
+
+  const response = await fetch(apiUrl, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "opensrc-cli",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(
+        `Repository "${owner}/${repo}" not found on GitHub. ` +
+          `Make sure it exists and is public.`,
+      );
+    }
+    if (response.status === 403) {
+      throw new Error(
+        `GitHub API rate limit exceeded. Try again later or authenticate.`,
+      );
+    }
+    throw new Error(
+      `Failed to fetch repository info: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as GitHubApiResponse;
+  const resolvedRef = ref || data.default_branch;
+
+  return {
+    host,
+    owner,
+    repo,
+    ref: resolvedRef,
+    repoUrl: `https://github.com/${owner}/${repo}`,
+    displayName: `${host}/${owner}/${repo}`,
+  };
+}
+
+async function resolveGitLabRepo(
+  host: string,
+  owner: string,
+  repo: string,
+  ref?: string,
+): Promise<ResolvedRepo> {
+  const projectPath = encodeURIComponent(`${owner}/${repo}`);
+  const apiUrl = `https://gitlab.com/api/v4/projects/${projectPath}`;
+
+  const response = await fetch(apiUrl, {
+    headers: {
+      "User-Agent": "opensrc-cli",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(
+        `Repository "${owner}/${repo}" not found on GitLab. ` +
+          `Make sure it exists and is public.`,
+      );
+    }
+    throw new Error(
+      `Failed to fetch repository info: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as GitLabApiResponse;
+  const resolvedRef = ref || data.default_branch;
+
+  return {
+    host,
+    owner,
+    repo,
+    ref: resolvedRef,
+    repoUrl: `https://gitlab.com/${owner}/${repo}`,
+    displayName: `${host}/${owner}/${repo}`,
+  };
+}
+
+/**
+ * Convert a repo display name back to host/owner/repo format
+ */
+export function displayNameToSpec(displayName: string): {
+  host: string;
+  owner: string;
+  repo: string;
+} | null {
+  const parts = displayName.split("/");
+  if (parts.length !== 3) {
+    return null;
+  }
+  return { host: parts[0], owner: parts[1], repo: parts[2] };
+}
+
+/**
+ * @deprecated Use displayNameToSpec instead
+ */
+export function displayNameToOwnerRepo(displayName: string): {
+  owner: string;
+  repo: string;
+} | null {
+  // Handle old format: owner--repo
+  if (displayName.includes("--") && !displayName.includes("/")) {
+    const parts = displayName.split("--");
+    if (parts.length !== 2) {
+      return null;
+    }
+    return { owner: parts[0], repo: parts[1] };
+  }
+
+  // Handle new format: host/owner/repo
+  const spec = displayNameToSpec(displayName);
+  if (!spec) {
+    return null;
+  }
+  return { owner: spec.owner, repo: spec.repo };
+}

--- a/opensrc/src/types.ts
+++ b/opensrc/src/types.ts
@@ -34,6 +34,7 @@ export interface ResolvedPackage {
   name: string;
   version: string;
   repoUrl: string;
+  cloneUrl?: string; // authenticated URL for private repos (never logged or stored)
   repoDirectory?: string;
   gitTag: string;
 }
@@ -85,5 +86,6 @@ export interface ResolvedRepo {
   repo: string;
   ref: string; // branch, tag, or commit (resolved)
   repoUrl: string;
+  cloneUrl?: string; // authenticated URL for private repos (never logged or stored)
   displayName: string; // e.g., "github.com/owner/repo"
 }

--- a/opensrc/src/types.ts
+++ b/opensrc/src/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Supported package registries
+ */
+export type Registry = "npm" | "pypi" | "crates";
+
+export interface PackageInfo {
+  name: string;
+  version: string;
+  repository?: {
+    type: string;
+    url: string;
+    directory?: string;
+  };
+}
+
+export interface RegistryResponse {
+  name: string;
+  "dist-tags": {
+    latest: string;
+    [key: string]: string;
+  };
+  versions: {
+    [version: string]: PackageInfo;
+  };
+  repository?: {
+    type: string;
+    url: string;
+    directory?: string;
+  };
+}
+
+export interface ResolvedPackage {
+  registry: Registry;
+  name: string;
+  version: string;
+  repoUrl: string;
+  repoDirectory?: string;
+  gitTag: string;
+}
+
+export interface FetchResult {
+  package: string;
+  version: string;
+  path: string;
+  success: boolean;
+  error?: string;
+  registry?: Registry;
+}
+
+export interface InstalledPackage {
+  name: string;
+  version: string;
+}
+
+/**
+ * Parsed repository specification
+ */
+export interface RepoSpec {
+  host: string; // e.g., "github.com", "gitlab.com"
+  owner: string;
+  repo: string;
+  ref?: string; // branch, tag, or commit
+}
+
+/**
+ * Type of input: package (with ecosystem) or git repo
+ */
+export type InputType = "package" | "repo";
+
+/**
+ * Parsed package specification with registry
+ */
+export interface PackageSpec {
+  registry: Registry;
+  name: string;
+  version?: string;
+}
+
+/**
+ * Resolved repository information (for git repos)
+ */
+export interface ResolvedRepo {
+  host: string; // e.g., "github.com", "gitlab.com"
+  owner: string;
+  repo: string;
+  ref: string; // branch, tag, or commit (resolved)
+  repoUrl: string;
+  displayName: string; // e.g., "github.com/owner/repo"
+}

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getAuthenticatedCloneUrl } from "./auth.js";
+
+describe("getAuthenticatedCloneUrl", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.OPENSRC_GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.OPENSRC_GITLAB_TOKEN;
+    delete process.env.GITLAB_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("GitHub", () => {
+    it("returns authenticated URL when OPENSRC_GITHUB_TOKEN is set", () => {
+      process.env.OPENSRC_GITHUB_TOKEN = "ghp_test123";
+      expect(getAuthenticatedCloneUrl("https://github.com/owner/repo")).toBe(
+        "https://x-access-token:ghp_test123@github.com/owner/repo",
+      );
+    });
+
+    it("falls back to GITHUB_TOKEN", () => {
+      process.env.GITHUB_TOKEN = "ghp_fallback";
+      expect(getAuthenticatedCloneUrl("https://github.com/owner/repo")).toBe(
+        "https://x-access-token:ghp_fallback@github.com/owner/repo",
+      );
+    });
+
+    it("prefers OPENSRC_GITHUB_TOKEN over GITHUB_TOKEN", () => {
+      process.env.OPENSRC_GITHUB_TOKEN = "ghp_primary";
+      process.env.GITHUB_TOKEN = "ghp_fallback";
+      expect(getAuthenticatedCloneUrl("https://github.com/owner/repo")).toBe(
+        "https://x-access-token:ghp_primary@github.com/owner/repo",
+      );
+    });
+
+    it("returns undefined when no token is set", () => {
+      expect(
+        getAuthenticatedCloneUrl("https://github.com/owner/repo"),
+      ).toBeUndefined();
+    });
+
+    it("strips .git suffix from URL", () => {
+      process.env.OPENSRC_GITHUB_TOKEN = "ghp_test";
+      expect(
+        getAuthenticatedCloneUrl("https://github.com/owner/repo.git"),
+      ).toBe("https://x-access-token:ghp_test@github.com/owner/repo");
+    });
+  });
+
+  describe("GitLab", () => {
+    it("returns authenticated URL when OPENSRC_GITLAB_TOKEN is set", () => {
+      process.env.OPENSRC_GITLAB_TOKEN = "glpat_test123";
+      expect(getAuthenticatedCloneUrl("https://gitlab.com/owner/repo")).toBe(
+        "https://oauth2:glpat_test123@gitlab.com/owner/repo",
+      );
+    });
+
+    it("falls back to GITLAB_TOKEN", () => {
+      process.env.GITLAB_TOKEN = "glpat_fallback";
+      expect(getAuthenticatedCloneUrl("https://gitlab.com/owner/repo")).toBe(
+        "https://oauth2:glpat_fallback@gitlab.com/owner/repo",
+      );
+    });
+
+    it("returns undefined when no token is set", () => {
+      expect(
+        getAuthenticatedCloneUrl("https://gitlab.com/owner/repo"),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("unsupported hosts", () => {
+    it("returns undefined for bitbucket", () => {
+      expect(
+        getAuthenticatedCloneUrl("https://bitbucket.org/owner/repo"),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for unknown hosts", () => {
+      expect(
+        getAuthenticatedCloneUrl("https://example.com/owner/repo"),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("invalid input", () => {
+    it("returns undefined for non-URL strings", () => {
+      expect(getAuthenticatedCloneUrl("not-a-url")).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,34 @@
+/**
+ * Build an authenticated clone URL for a repo if a matching token is available.
+ * Returns undefined when no token is set for the host.
+ */
+export function getAuthenticatedCloneUrl(
+  repoUrl: string,
+): string | undefined {
+  let host: string;
+  let path: string;
+
+  try {
+    const url = new URL(repoUrl);
+    host = url.hostname;
+    path = url.pathname.replace(/^\//, "").replace(/\.git$/, "");
+  } catch {
+    return undefined;
+  }
+
+  if (host === "github.com") {
+    const token =
+      process.env.OPENSRC_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+    if (token) {
+      return `https://x-access-token:${token}@github.com/${path}`;
+    }
+  } else if (host === "gitlab.com") {
+    const token =
+      process.env.OPENSRC_GITLAB_TOKEN || process.env.GITLAB_TOKEN;
+    if (token) {
+      return `https://oauth2:${token}@gitlab.com/${path}`;
+    }
+  }
+
+  return undefined;
+}

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -364,13 +364,9 @@ export async function fetchRepoSource(
     await mkdir(parentDir, { recursive: true });
   }
 
-  // Clone the repository
-  const cloneResult = await cloneAtRef(
-    git,
-    resolved.repoUrl,
-    repoPath,
-    resolved.ref,
-  );
+  // Clone the repository (prefer authenticated URL for private repos)
+  const cloneUrl = resolved.cloneUrl || resolved.repoUrl;
+  const cloneResult = await cloneAtRef(git, cloneUrl, repoPath, resolved.ref);
 
   if (!cloneResult.success) {
     return {

--- a/src/lib/registries/crates.ts
+++ b/src/lib/registries/crates.ts
@@ -1,4 +1,5 @@
 import type { ResolvedPackage } from "../../types.js";
+import { getAuthenticatedCloneUrl } from "../auth.js";
 
 const CRATES_API = "https://crates.io/api/v1";
 
@@ -186,6 +187,7 @@ export async function resolveCrate(
     name: crateName,
     version: resolvedVersion,
     repoUrl,
+    cloneUrl: getAuthenticatedCloneUrl(repoUrl),
     gitTag,
   };
 }

--- a/src/lib/registries/npm.ts
+++ b/src/lib/registries/npm.ts
@@ -1,4 +1,5 @@
 import type { RegistryResponse, ResolvedPackage } from "../../types.js";
+import { getAuthenticatedCloneUrl } from "../auth.js";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
 
@@ -140,6 +141,7 @@ export async function resolveNpmPackage(
     name: packageName,
     version: resolvedVersion,
     repoUrl: repo.url,
+    cloneUrl: getAuthenticatedCloneUrl(repo.url),
     repoDirectory: repo.directory,
     gitTag,
   };

--- a/src/lib/registries/pypi.ts
+++ b/src/lib/registries/pypi.ts
@@ -1,4 +1,5 @@
 import type { ResolvedPackage } from "../../types.js";
+import { getAuthenticatedCloneUrl } from "../auth.js";
 
 const PYPI_API = "https://pypi.org/pypi";
 
@@ -178,6 +179,7 @@ export async function resolvePyPIPackage(
     name: packageName,
     version: resolvedVersion,
     repoUrl,
+    cloneUrl: getAuthenticatedCloneUrl(repoUrl),
     gitTag,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface ResolvedPackage {
   name: string;
   version: string;
   repoUrl: string;
+  cloneUrl?: string; // authenticated URL for private repos (never logged or stored)
   repoDirectory?: string;
   gitTag: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,5 +85,6 @@ export interface ResolvedRepo {
   repo: string;
   ref: string; // branch, tag, or commit (resolved)
   repoUrl: string;
+  cloneUrl?: string; // authenticated URL for private repos (never logged or stored)
   displayName: string; // e.g., "github.com/owner/repo"
 }


### PR DESCRIPTION
Adds support for fetching source code from private GitHub and GitLab repositories by reading authentication tokens from environment variables.

- `OPENSRC_GITHUB_TOKEN` (or `GITHUB_TOKEN`) for GitHub API calls and authenticated cloning
- `OPENSRC_GITLAB_TOKEN` (or `GITLAB_TOKEN`) for GitLab API calls and authenticated cloning
- Improved error messages to guide users toward setting tokens when needed
- Tokens are never logged or persisted to `sources.json`