### PR TITLE
Added full support for Nuget package resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ To fetch source code for a package or repository you need to understand, run:
 npx opensrc <package>           # npm package (e.g., npx opensrc zod)
 npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
 npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
+npx opensrc nuget:<package>     # NuGet package (e.g., npx opensrc nuget:Newtonsoft.Json)
 npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opensrc
 
-Fetch source code for npm packages to give coding agents deeper context than types alone.
+Fetch source code for packages and repositories to give coding agents deeper context than types alone.
 
 ## Why?
 
@@ -36,6 +36,29 @@ opensrc react react-dom next
 ```
 
 Re-running `opensrc <package>` automatically updates to match your installed version—no flags needed.
+
+### Other Registries (PyPI, crates.io, NuGet)
+
+```bash
+# Python package from PyPI
+opensrc pypi:requests
+
+# Rust crate from crates.io
+opensrc crates:serde
+
+# NuGet package (latest)
+opensrc nuget:Newtonsoft.Json
+
+# NuGet package (latest including prerelease)
+opensrc nuget:Serilog --allow-prerelease
+
+# NuGet package (specific version)
+opensrc nuget:Serilog@3.1.0
+
+# NuGet aliases
+opensrc dotnet:Microsoft.Extensions.Logging@8.0.0
+opensrc nupkg:Serilog
+```
 
 ### GitHub Repositories
 
@@ -94,11 +117,18 @@ opensrc zod --modify=false
 
 ## How it works
 
-1. Queries the npm registry to find the package's repository URL
-2. Detects the installed version from your lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`)
-3. Clones the repository at the matching git tag
-4. Stores the source in `opensrc/<package-name>/`
+1. Queries the selected package registry to find the package's source repository URL
+2. For npm without an explicit version, detects installed version from your lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`)
+3. Clones the repository at a version-aligned git tag when possible
+4. Stores the source in `opensrc/repos/<host>/<owner>/<repo>/`
 5. If permitted: adds `opensrc/` to `.gitignore`, excludes from `tsconfig.json`, updates `AGENTS.md`
+
+Supported package registries:
+
+- npm (default)
+- PyPI (`pypi:` / `pip:` / `python:`)
+- crates.io (`crates:` / `cargo:` / `rust:`)
+- NuGet (`nuget:` / `dotnet:` / `nupkg:`)
 
 ## Output
 

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -35,6 +35,8 @@ export interface FetchOptions {
   cwd?: string;
   /** Override file modification permission: true = allow, false = deny, undefined = prompt */
   allowModifications?: boolean;
+  /** Allow prerelease versions when resolving latest NuGet packages */
+  allowPrerelease?: boolean;
 }
 
 /**
@@ -90,6 +92,8 @@ function getRegistryLabel(registry: Registry): string {
       return "PyPI";
     case "crates":
       return "crates.io";
+    case "nuget":
+      return "NuGet";
   }
 }
 
@@ -172,6 +176,7 @@ async function fetchRepoInput(spec: string, cwd: string): Promise<FetchResult> {
 async function fetchPackageInput(
   spec: string,
   cwd: string,
+  options: FetchOptions,
 ): Promise<FetchResult> {
   const packageSpec = parsePackageSpec(spec);
   const { registry, name } = packageSpec;
@@ -219,6 +224,7 @@ async function fetchPackageInput(
       registry,
       name,
       version,
+      allowPrerelease: options.allowPrerelease,
     });
 
     const repoDisplayName = getRepoDisplayName(resolved.repoUrl);
@@ -353,7 +359,7 @@ export async function fetchCommand(
       const result = await fetchRepoInput(spec, cwd);
       results.push(result);
     } else {
-      const result = await fetchPackageInput(spec, cwd);
+      const result = await fetchPackageInput(spec, cwd, options);
       results.push(result);
     }
   }

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/git.js", () => ({
+  listSources: vi.fn(),
+}));
+
+import { listCommand } from "./list.js";
+import { listSources } from "../lib/git.js";
+
+describe("listCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prints NuGet in supported registries when empty", async () => {
+    vi.mocked(listSources).mockResolvedValue({ packages: [], repos: [] });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await listCommand();
+
+    const output = logSpy.mock.calls.map(([line]) => String(line)).join("\n");
+    expect(output).toContain("NuGet");
+    expect(output).toContain("nuget:Newtonsoft.Json");
+  });
+
+  it("groups NuGet packages in their own section", async () => {
+    vi.mocked(listSources).mockResolvedValue({
+      packages: [
+        {
+          name: "Serilog",
+          version: "3.1.0",
+          registry: "nuget",
+          path: "repos/github.com/serilog/serilog",
+          fetchedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      repos: [],
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await listCommand();
+
+    const output = logSpy.mock.calls.map(([line]) => String(line)).join("\n");
+    expect(output).toContain("NuGet Packages:");
+    expect(output).toContain("1 NuGet");
+  });
+});

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -10,6 +10,7 @@ const REGISTRY_LABELS: Record<Registry, string> = {
   npm: "npm",
   pypi: "PyPI",
   crates: "crates.io",
+  nuget: "NuGet",
 };
 
 /**
@@ -31,6 +32,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
     console.log("  • npm:      opensrc zod, opensrc npm:react");
     console.log("  • PyPI:     opensrc pypi:requests");
     console.log("  • crates:   opensrc crates:serde");
+    console.log("  • NuGet:    opensrc nuget:Newtonsoft.Json");
     return;
   }
 
@@ -44,6 +46,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
     npm: [],
     pypi: [],
     crates: [],
+    nuget: [],
   };
 
   for (const pkg of sources.packages) {
@@ -51,7 +54,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
   }
 
   // Display packages by registry
-  const registries: Registry[] = ["npm", "pypi", "crates"];
+  const registries: Registry[] = ["npm", "pypi", "crates", "nuget"];
   let hasDisplayedPackages = false;
 
   for (const registry of registries) {

--- a/src/commands/remove.test.ts
+++ b/src/commands/remove.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/git.js", () => ({
+  removePackageSource: vi.fn(),
+  removeRepoSource: vi.fn(),
+  repoExists: vi.fn(),
+  listSources: vi.fn(),
+  getPackageInfo: vi.fn(),
+}));
+
+vi.mock("../lib/agents.js", () => ({
+  updateAgentsMd: vi.fn(),
+  updatePackageIndex: vi.fn(),
+}));
+
+vi.mock("../lib/settings.js", () => ({
+  getFileModificationPermission: vi.fn(),
+}));
+
+vi.mock("../lib/repo.js", () => ({
+  isRepoSpec: vi.fn(() => false),
+}));
+
+vi.mock("../lib/registries/index.js", () => ({
+  detectRegistry: vi.fn(() => ({ registry: "npm", cleanSpec: "Serilog" })),
+}));
+
+import { removeCommand } from "./remove.js";
+import { getFileModificationPermission } from "../lib/settings.js";
+import { detectRegistry } from "../lib/registries/index.js";
+import { getPackageInfo, removePackageSource, listSources } from "../lib/git.js";
+
+describe("removeCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getFileModificationPermission).mockResolvedValue(false);
+    vi.mocked(listSources).mockResolvedValue({ packages: [], repos: [] });
+  });
+
+  it("falls back through nuget registry when default lookup misses", async () => {
+    vi.mocked(detectRegistry).mockReturnValue({
+      registry: "npm",
+      cleanSpec: "Serilog",
+    });
+
+    vi.mocked(getPackageInfo)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        name: "Serilog",
+        version: "3.1.0",
+        registry: "nuget",
+        path: "repos/github.com/serilog/serilog",
+        fetchedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+    vi.mocked(removePackageSource).mockResolvedValue({
+      removed: true,
+      repoRemoved: false,
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await removeCommand(["Serilog"]);
+
+    expect(getPackageInfo).toHaveBeenCalledWith("Serilog", expect.any(String), "nuget");
+    expect(removePackageSource).toHaveBeenCalledWith(
+      "Serilog",
+      expect.any(String),
+      "nuget",
+    );
+
+    const output = logSpy.mock.calls.map(([line]) => String(line)).join("\n");
+    expect(output).toContain("(nuget)");
+  });
+});

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -78,7 +78,7 @@ export async function removeCommand(
 
       if (!pkgInfo) {
         // Try other registries if default didn't work
-        const registries: Registry[] = ["npm", "pypi", "crates"];
+        const registries: Registry[] = ["npm", "pypi", "crates", "nuget"];
         for (const reg of registries) {
           if (reg !== registry) {
             pkgInfo = await getPackageInfo(cleanSpec, cwd, reg);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,6 +6,7 @@ vi.mock("./commands/remove.js", () => ({ removeCommand: vi.fn() }));
 vi.mock("./commands/clean.js", () => ({ cleanCommand: vi.fn() }));
 
 import { createProgram } from "./index.js";
+import { fetchCommand } from "./commands/fetch.js";
 import { listCommand } from "./commands/list.js";
 import { removeCommand } from "./commands/remove.js";
 import { cleanCommand } from "./commands/clean.js";
@@ -15,6 +16,21 @@ beforeEach(() => {
 });
 
 describe("CLI --cwd routing", () => {
+  it("passes --allow-prerelease to fetch command", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "opensrc",
+      "nuget:Serilog",
+      "--allow-prerelease",
+    ]);
+
+    expect(fetchCommand).toHaveBeenCalledWith(
+      ["nuget:Serilog"],
+      expect.objectContaining({ allowPrerelease: true }),
+    );
+  });
+
   it("passes --cwd to list subcommand", async () => {
     const program = createProgram();
     await program.parseAsync(["node", "opensrc", "list", "--cwd", "/tmp/foo"]);
@@ -53,6 +69,18 @@ describe("CLI --cwd routing", () => {
 
     expect(cleanCommand).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: "/tmp/baz" }),
+    );
+  });
+
+  it("routes clean --nuget to nuget registry", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "opensrc", "clean", "--nuget"]);
+
+    expect(cleanCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packages: true,
+        registry: "nuget",
+      }),
     );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,13 @@ export function createProgram(): Command {
   program
     .argument(
       "[packages...]",
-      "packages or repos to fetch (e.g., zod, pypi:requests, crates:serde, owner/repo)",
+      "packages or repos to fetch (e.g., zod, pypi:requests, crates:serde, nuget:Newtonsoft.Json, owner/repo)",
     )
     .option("--cwd <path>", "working directory (default: current directory)")
+    .option(
+      "--allow-prerelease",
+      "allow prerelease versions when resolving latest NuGet packages",
+    )
     .option(
       "--modify [value]",
       "allow/deny modifying .gitignore, tsconfig.json, AGENTS.md",
@@ -42,7 +46,7 @@ export function createProgram(): Command {
     .action(
       async (
         packages: string[],
-        options: { cwd?: string; modify?: boolean },
+        options: { cwd?: string; modify?: boolean; allowPrerelease?: boolean },
       ) => {
         if (packages.length === 0) {
           program.help();
@@ -52,6 +56,7 @@ export function createProgram(): Command {
         await fetchCommand(packages, {
           cwd: options.cwd,
           allowModifications: options.modify,
+          allowPrerelease: options.allowPrerelease,
         });
       },
     );
@@ -90,6 +95,7 @@ export function createProgram(): Command {
     .option("--npm", "only remove npm packages")
     .option("--pypi", "only remove PyPI packages")
     .option("--crates", "only remove crates.io packages")
+    .option("--nuget", "only remove NuGet packages")
     .option("--cwd <path>", "working directory (default: current directory)")
     .action(
       async (options: {
@@ -98,12 +104,14 @@ export function createProgram(): Command {
         npm?: boolean;
         pypi?: boolean;
         crates?: boolean;
+        nuget?: boolean;
         cwd?: string;
       }) => {
         let registry: Registry | undefined;
         if (options.npm) registry = "npm";
         else if (options.pypi) registry = "pypi";
         else if (options.crates) registry = "crates";
+        else if (options.nuget) registry = "nuget";
 
         await cleanCommand({
           packages: options.packages || !!registry,

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -32,6 +32,7 @@ To fetch source code for a package or repository you need to understand, run:
 npx opensrc <package>           # npm package (e.g., npx opensrc zod)
 npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
 npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
+npx opensrc nuget:<package>     # NuGet package (e.g., npx opensrc nuget:Newtonsoft.Json)
 npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
 \`\`\`
 

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -34,7 +34,7 @@ afterEach(async () => {
 describe("path helpers", () => {
   describe("getOpensrcDir", () => {
     it("returns opensrc directory path", () => {
-      expect(getOpensrcDir("/project")).toBe("/project/opensrc");
+      expect(getOpensrcDir("/project")).toBe(join("/project", "opensrc"));
     });
 
     it("uses cwd by default", () => {
@@ -44,20 +44,22 @@ describe("path helpers", () => {
 
   describe("getReposDir", () => {
     it("returns repos directory path", () => {
-      expect(getReposDir("/project")).toBe("/project/opensrc/repos");
+      expect(getReposDir("/project")).toBe(
+        join("/project", "opensrc", "repos"),
+      );
     });
   });
 
   describe("getRepoPath", () => {
     it("returns full path for repo", () => {
       expect(getRepoPath("github.com/vercel/ai", "/project")).toBe(
-        "/project/opensrc/repos/github.com/vercel/ai",
+        join("/project", "opensrc", "repos", "github.com", "vercel", "ai"),
       );
     });
 
     it("handles different hosts", () => {
       expect(getRepoPath("gitlab.com/owner/repo", "/project")).toBe(
-        "/project/opensrc/repos/gitlab.com/owner/repo",
+        join("/project", "opensrc", "repos", "gitlab.com", "owner", "repo"),
       );
     });
   });

--- a/src/lib/registries/index.test.ts
+++ b/src/lib/registries/index.test.ts
@@ -85,6 +85,29 @@ describe("detectRegistry", () => {
     });
   });
 
+  describe("nuget registry", () => {
+    it("detects nuget: prefix", () => {
+      expect(detectRegistry("nuget:Newtonsoft.Json")).toEqual({
+        registry: "nuget",
+        cleanSpec: "Newtonsoft.Json",
+      });
+    });
+
+    it("detects dotnet: alias", () => {
+      expect(detectRegistry("dotnet:Serilog")).toEqual({
+        registry: "nuget",
+        cleanSpec: "Serilog",
+      });
+    });
+
+    it("detects nupkg: alias", () => {
+      expect(detectRegistry("nupkg:Microsoft.Extensions.Logging")).toEqual({
+        registry: "nuget",
+        cleanSpec: "Microsoft.Extensions.Logging",
+      });
+    });
+  });
+
   describe("preserves version in cleanSpec", () => {
     it("npm with version", () => {
       expect(detectRegistry("npm:lodash@4.17.21")).toEqual({
@@ -104,6 +127,13 @@ describe("detectRegistry", () => {
       expect(detectRegistry("crates:serde@1.0.0")).toEqual({
         registry: "crates",
         cleanSpec: "serde@1.0.0",
+      });
+    });
+
+    it("nuget with version", () => {
+      expect(detectRegistry("nuget:Serilog@3.1.0")).toEqual({
+        registry: "nuget",
+        cleanSpec: "Serilog@3.1.0",
       });
     });
   });
@@ -179,6 +209,24 @@ describe("parsePackageSpec", () => {
       });
     });
   });
+
+  describe("nuget packages", () => {
+    it("parses nuget package", () => {
+      expect(parsePackageSpec("nuget:Newtonsoft.Json")).toEqual({
+        registry: "nuget",
+        name: "Newtonsoft.Json",
+        version: undefined,
+      });
+    });
+
+    it("parses nuget package with version", () => {
+      expect(parsePackageSpec("dotnet:Serilog@3.1.0")).toEqual({
+        registry: "nuget",
+        name: "Serilog",
+        version: "3.1.0",
+      });
+    });
+  });
 });
 
 describe("detectInputType", () => {
@@ -201,6 +249,10 @@ describe("detectInputType", () => {
 
     it("crates package", () => {
       expect(detectInputType("crates:serde")).toBe("package");
+    });
+
+    it("nuget package", () => {
+      expect(detectInputType("nuget:Newtonsoft.Json")).toBe("package");
     });
 
     it("package with version", () => {

--- a/src/lib/registries/index.ts
+++ b/src/lib/registries/index.ts
@@ -2,11 +2,13 @@ import type { Registry, PackageSpec, ResolvedPackage } from "../../types.js";
 import { parseNpmSpec, resolveNpmPackage } from "./npm.js";
 import { parsePyPISpec, resolvePyPIPackage } from "./pypi.js";
 import { parseCratesSpec, resolveCrate } from "./crates.js";
+import { parseNuGetSpec, resolveNuGetPackage } from "./nuget.js";
 import { isRepoSpec } from "../repo.js";
 
 export { resolveNpmPackage } from "./npm.js";
 export { resolvePyPIPackage } from "./pypi.js";
 export { resolveCrate } from "./crates.js";
+export { resolveNuGetPackage } from "./nuget.js";
 
 /**
  * Registry prefixes for explicit specification
@@ -19,6 +21,9 @@ const REGISTRY_PREFIXES: Record<string, Registry> = {
   "crates:": "crates",
   "cargo:": "crates",
   "rust:": "crates",
+  "nuget:": "nuget",
+  "dotnet:": "nuget",
+  "nupkg:": "nuget",
 };
 
 /**
@@ -67,6 +72,9 @@ export function parsePackageSpec(spec: string): PackageSpec {
     case "crates":
       ({ name, version } = parseCratesSpec(cleanSpec));
       break;
+    case "nuget":
+      ({ name, version } = parseNuGetSpec(cleanSpec));
+      break;
   }
 
   return { registry, name, version };
@@ -78,7 +86,7 @@ export function parsePackageSpec(spec: string): PackageSpec {
 export async function resolvePackage(
   spec: PackageSpec,
 ): Promise<ResolvedPackage> {
-  const { registry, name, version } = spec;
+  const { registry, name, version, allowPrerelease } = spec;
 
   switch (registry) {
     case "npm":
@@ -87,6 +95,8 @@ export async function resolvePackage(
       return resolvePyPIPackage(name, version);
     case "crates":
       return resolveCrate(name, version);
+    case "nuget":
+      return resolveNuGetPackage(name, version, { allowPrerelease });
   }
 }
 

--- a/src/lib/registries/nuget.test.ts
+++ b/src/lib/registries/nuget.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { __internal, parseNuGetSpec, resolveNuGetPackage } from "./nuget.js";
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function textResponse(data: string, status = 200): Response {
+  return new Response(data, {
+    status,
+    headers: { "content-type": "application/xml" },
+  });
+}
+
+describe("parseNuGetSpec", () => {
+  it("parses package name only", () => {
+    expect(parseNuGetSpec("Newtonsoft.Json")).toEqual({
+      name: "Newtonsoft.Json",
+      version: undefined,
+    });
+  });
+
+  it("parses package with version", () => {
+    expect(parseNuGetSpec("Serilog@3.1.0")).toEqual({
+      name: "Serilog",
+      version: "3.1.0",
+    });
+  });
+});
+
+describe("normalizeNuGetRepoUrl", () => {
+  it("normalizes git+ URL and strips tree path", () => {
+    expect(
+      __internal.normalizeNuGetRepoUrl(
+        "git+https://github.com/serilog/serilog.git/tree/dev?x=1#frag",
+      ),
+    ).toBe("https://github.com/serilog/serilog");
+  });
+
+  it("rejects non-repo URLs", () => {
+    expect(__internal.normalizeNuGetRepoUrl("https://github.com/serilog")).toBe(
+      null,
+    );
+  });
+});
+
+describe("resolveNuGetPackage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses registration repository metadata when available", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = String(input);
+
+        if (url.endsWith("/v3/index.json")) {
+          return jsonResponse({
+            resources: [
+              { "@type": "RegistrationsBaseUrl/3.6.0", "@id": "https://reg/" },
+              { "@type": "PackageBaseAddress/3.0.0", "@id": "https://flat/" },
+            ],
+          });
+        }
+
+        if (url === "https://reg/newtonsoft.json/index.json") {
+          return jsonResponse({
+            items: [
+              {
+                items: [
+                  {
+                    catalogEntry: {
+                      version: "13.0.3",
+                      repository: {
+                        type: "git",
+                        url: "https://github.com/jamesnk/newtonsoft.json.git",
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          });
+        }
+
+        throw new Error(`unexpected fetch URL: ${url}`);
+      });
+
+    const resolved = await resolveNuGetPackage("Newtonsoft.Json");
+
+    expect(resolved.registry).toBe("nuget");
+    expect(resolved.version).toBe("13.0.3");
+    expect(resolved.repoUrl).toBe("https://github.com/jamesnk/newtonsoft.json");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to nuspec repository metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith("/v3/index.json")) {
+        return jsonResponse({
+          resources: [
+            { "@type": "RegistrationsBaseUrl/3.6.0", "@id": "https://reg/" },
+            { "@type": "PackageBaseAddress/3.0.0", "@id": "https://flat/" },
+          ],
+        });
+      }
+
+      if (url === "https://reg/serilog/index.json") {
+        return jsonResponse({
+          items: [{ items: [{ catalogEntry: { version: "3.1.0" } }] }],
+        });
+      }
+
+      if (url === "https://flat/serilog/3.1.0/serilog.nuspec") {
+        return textResponse(
+          '<package><metadata><repository type="git" url="https://github.com/serilog/serilog.git" /></metadata></package>',
+        );
+      }
+
+      throw new Error(`unexpected fetch URL: ${url}`);
+    });
+
+    const resolved = await resolveNuGetPackage("Serilog", "3.1.0");
+    expect(resolved.repoUrl).toBe("https://github.com/serilog/serilog");
+  });
+
+  it("defaults to latest stable when newer prerelease exists", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith("/v3/index.json")) {
+        return jsonResponse({
+          resources: [
+            { "@type": "RegistrationsBaseUrl/3.6.0", "@id": "https://reg/" },
+            { "@type": "PackageBaseAddress/3.0.0", "@id": "https://flat/" },
+          ],
+        });
+      }
+
+      if (url === "https://reg/serilog/index.json") {
+        return jsonResponse({
+          items: [
+            {
+              items: [
+                {
+                  catalogEntry: {
+                    version: "4.3.2-dev-02419",
+                    repository: {
+                      type: "git",
+                      url: "https://github.com/serilog/serilog.git",
+                    },
+                  },
+                },
+                {
+                  catalogEntry: {
+                    version: "4.3.1",
+                    repository: {
+                      type: "git",
+                      url: "https://github.com/serilog/serilog.git",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      }
+
+      throw new Error(`unexpected fetch URL: ${url}`);
+    });
+
+    const resolved = await resolveNuGetPackage("Serilog");
+    expect(resolved.version).toBe("4.3.1");
+  });
+
+  it("fails when package has only prerelease versions and no explicit version", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith("/v3/index.json")) {
+        return jsonResponse({
+          resources: [
+            { "@type": "RegistrationsBaseUrl/3.6.0", "@id": "https://reg/" },
+            { "@type": "PackageBaseAddress/3.0.0", "@id": "https://flat/" },
+          ],
+        });
+      }
+
+      if (url === "https://reg/example.pkg/index.json") {
+        return jsonResponse({
+          items: [
+            {
+              items: [
+                {
+                  catalogEntry: {
+                    version: "1.0.0-beta.1",
+                    repository: {
+                      type: "git",
+                      url: "https://github.com/org/repo.git",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      }
+
+      throw new Error(`unexpected fetch URL: ${url}`);
+    });
+
+    await expect(resolveNuGetPackage("Example.Pkg")).rejects.toThrow(
+      /No stable version found for "Example.Pkg"/,
+    );
+  });
+
+  it("uses latest prerelease when allowPrerelease is true", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith("/v3/index.json")) {
+        return jsonResponse({
+          resources: [
+            { "@type": "RegistrationsBaseUrl/3.6.0", "@id": "https://reg/" },
+            { "@type": "PackageBaseAddress/3.0.0", "@id": "https://flat/" },
+          ],
+        });
+      }
+
+      if (url === "https://reg/serilog/index.json") {
+        return jsonResponse({
+          items: [
+            {
+              items: [
+                {
+                  catalogEntry: {
+                    version: "4.3.2-dev-02419",
+                    repository: {
+                      type: "git",
+                      url: "https://github.com/serilog/serilog.git",
+                    },
+                  },
+                },
+                {
+                  catalogEntry: {
+                    version: "4.3.1",
+                    repository: {
+                      type: "git",
+                      url: "https://github.com/serilog/serilog.git",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      }
+
+      throw new Error(`unexpected fetch URL: ${url}`);
+    });
+
+    const resolved = await resolveNuGetPackage("Serilog", undefined, {
+      allowPrerelease: true,
+    });
+    expect(resolved.version).toBe("4.3.2-dev-02419");
+  });
+
+  it("fails when only invalid projectUrl is available", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith("/v3/index.json")) {
+        return jsonResponse({
+          resources: [
+            { "@type": "RegistrationsBaseUrl/3.6.0", "@id": "https://reg/" },
+            { "@type": "PackageBaseAddress/3.0.0", "@id": "https://flat/" },
+          ],
+        });
+      }
+
+      if (url === "https://reg/example.pkg/index.json") {
+        return jsonResponse({
+          items: [
+            {
+              items: [
+                {
+                  catalogEntry: {
+                    version: "1.0.0",
+                    projectUrl: "https://github.com/org",
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      }
+
+      if (url === "https://flat/example.pkg/1.0.0/example.pkg.nuspec") {
+        return textResponse("<package><metadata /></package>");
+      }
+
+      throw new Error(`unexpected fetch URL: ${url}`);
+    });
+
+    await expect(resolveNuGetPackage("Example.Pkg", "1.0.0")).rejects.toThrow(
+      /Invalid non-cloneable projectUrl URL/,
+    );
+  });
+});

--- a/src/lib/registries/nuget.ts
+++ b/src/lib/registries/nuget.ts
@@ -1,0 +1,497 @@
+import type { ResolvedPackage } from "../../types.js";
+
+const NUGET_SERVICE_INDEX = "https://api.nuget.org/v3/index.json";
+const ALLOWED_GIT_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+interface NuGetServiceIndex {
+  resources?: Array<{
+    "@id"?: string;
+    "@type"?: string;
+  }>;
+}
+
+interface RegistrationLeaf {
+  catalogEntry?: {
+    version?: string;
+    repository?: {
+      type?: string;
+      url?: string;
+      branch?: string;
+      commit?: string;
+    };
+    projectUrl?: string;
+  };
+}
+
+interface RegistrationPage {
+  items?: RegistrationLeaf[];
+  "@id"?: string;
+}
+
+interface RegistrationIndex {
+  items?: RegistrationPage[];
+}
+
+interface NuGetMetadataCandidate {
+  source: "repository" | "projectUrl";
+  url: string;
+}
+
+function toComparableVersion(version: string): string {
+  return version.trim().toLowerCase();
+}
+
+function isPrereleaseVersion(version: string): boolean {
+  return version.includes("-");
+}
+
+function comparePrereleaseIdentifiers(a: string, b: string): number {
+  const aParts = a.split(".");
+  const bParts = b.split(".");
+  const maxLen = Math.max(aParts.length, bParts.length);
+
+  for (let i = 0; i < maxLen; i += 1) {
+    const aPart = aParts[i];
+    const bPart = bParts[i];
+
+    if (aPart === undefined) return -1;
+    if (bPart === undefined) return 1;
+
+    const aNum = /^\d+$/.test(aPart);
+    const bNum = /^\d+$/.test(bPart);
+
+    if (aNum && bNum) {
+      const diff = Number(aPart) - Number(bPart);
+      if (diff !== 0) return diff;
+      continue;
+    }
+
+    if (aNum && !bNum) return -1;
+    if (!aNum && bNum) return 1;
+
+    const cmp = aPart.localeCompare(bPart);
+    if (cmp !== 0) return cmp;
+  }
+
+  return 0;
+}
+
+function compareNuGetVersions(a: string, b: string): number {
+  const [aMain, aMeta] = a.split("+", 2);
+  const [bMain, bMeta] = b.split("+", 2);
+  const [aCore, aPre] = aMain.split("-", 2);
+  const [bCore, bPre] = bMain.split("-", 2);
+
+  const aCoreParts = aCore.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const bCoreParts = bCore.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const maxCoreLen = Math.max(aCoreParts.length, bCoreParts.length);
+
+  for (let i = 0; i < maxCoreLen; i += 1) {
+    const aVal = aCoreParts[i] ?? 0;
+    const bVal = bCoreParts[i] ?? 0;
+    if (aVal !== bVal) {
+      return aVal - bVal;
+    }
+  }
+
+  if (!aPre && bPre) return 1;
+  if (aPre && !bPre) return -1;
+  if (aPre && bPre) {
+    const preCmp = comparePrereleaseIdentifiers(aPre, bPre);
+    if (preCmp !== 0) return preCmp;
+  }
+
+  return (aMeta ?? "").localeCompare(bMeta ?? "");
+}
+
+function joinUrl(base: string, suffix: string): string {
+  return `${base.replace(/\/+$/, "")}/${suffix.replace(/^\/+/, "")}`;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "opensrc-cli",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch NuGet metadata: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function getNuGetResource(index: NuGetServiceIndex, typePrefix: string): string {
+  const resource = index.resources?.find((entry) =>
+    entry["@type"]?.toLowerCase().startsWith(typePrefix.toLowerCase()),
+  );
+
+  if (!resource?.["@id"]) {
+    throw new Error(
+      `NuGet service index does not provide required resource: ${typePrefix}`,
+    );
+  }
+
+  return resource["@id"];
+}
+
+async function fetchRegistrationLeaves(
+  registrationsBaseUrl: string,
+  packageId: string,
+): Promise<RegistrationLeaf[]> {
+  const packageLower = packageId.toLowerCase();
+  const indexUrl = joinUrl(registrationsBaseUrl, `${packageLower}/index.json`);
+  const response = await fetch(indexUrl, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "opensrc-cli",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return [];
+    }
+    throw new Error(
+      `Failed to fetch NuGet metadata: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const index = (await response.json()) as RegistrationIndex;
+
+  const leaves: RegistrationLeaf[] = [];
+
+  for (const page of index.items ?? []) {
+    if (page.items && page.items.length > 0) {
+      leaves.push(...page.items);
+      continue;
+    }
+
+    if (page["@id"]) {
+      const expandedPage = await fetchJson<RegistrationPage>(page["@id"]);
+      leaves.push(...(expandedPage.items ?? []));
+    }
+  }
+
+  return leaves;
+}
+
+function resolveVersionFromLeaves(
+  leaves: RegistrationLeaf[],
+  packageName: string,
+  requestedVersion?: string,
+  allowPrerelease: boolean = false,
+): string {
+  if (requestedVersion) {
+    const wanted = toComparableVersion(requestedVersion);
+    const matched = leaves.find(
+      (leaf) => toComparableVersion(leaf.catalogEntry?.version ?? "") === wanted,
+    );
+
+    if (!matched?.catalogEntry?.version) {
+      throw new Error(`Version "${requestedVersion}" not found on NuGet`);
+    }
+
+    return matched.catalogEntry.version;
+  }
+
+  const versions = leaves
+    .map((leaf) => leaf.catalogEntry?.version)
+    .filter((value): value is string => Boolean(value));
+
+  if (versions.length === 0) {
+    throw new Error("NuGet package has no published versions");
+  }
+
+  if (allowPrerelease) {
+    return versions.reduce((latest, current) =>
+      compareNuGetVersions(current, latest) > 0 ? current : latest,
+    );
+  }
+
+  const stableVersions = versions.filter((value) => !isPrereleaseVersion(value));
+
+  if (stableVersions.length > 0) {
+    return stableVersions.reduce((latest, current) =>
+      compareNuGetVersions(current, latest) > 0 ? current : latest,
+    );
+  }
+
+  throw new Error(
+    `No stable version found for "${packageName}" on NuGet. Specify a prerelease version explicitly (for example: nuget:${packageName}@<version>)`,
+  );
+}
+
+function findLeafByVersion(
+  leaves: RegistrationLeaf[],
+  version: string,
+): RegistrationLeaf | null {
+  const wanted = toComparableVersion(version);
+  return (
+    leaves.find(
+      (leaf) => toComparableVersion(leaf.catalogEntry?.version ?? "") === wanted,
+    ) ?? null
+  );
+}
+
+function extractRepositoryFromLeaf(leaf: RegistrationLeaf): NuGetMetadataCandidate | null {
+  const repository = leaf.catalogEntry?.repository;
+
+  if (
+    repository?.url &&
+    (!repository.type || repository.type.toLowerCase() === "git")
+  ) {
+    return { source: "repository", url: repository.url };
+  }
+
+  if (leaf.catalogEntry?.projectUrl) {
+    return { source: "projectUrl", url: leaf.catalogEntry.projectUrl };
+  }
+
+  return null;
+}
+
+function extractRepositoryFromNuspecXml(
+  xml: string,
+): NuGetMetadataCandidate | null {
+  const repositoryMatch = xml.match(/<repository\b[^>]*>/i);
+  if (repositoryMatch) {
+    const repositoryTag = repositoryMatch[0];
+    const typeMatch = repositoryTag.match(/\btype\s*=\s*"([^"]+)"/i);
+    const urlMatch = repositoryTag.match(/\burl\s*=\s*"([^"]+)"/i);
+
+    if (urlMatch && (!typeMatch || typeMatch[1].toLowerCase() === "git")) {
+      return {
+        source: "repository",
+        url: urlMatch[1],
+      };
+    }
+  }
+
+  const projectUrlMatch = xml.match(/<projectUrl>\s*([^<]+?)\s*<\/projectUrl>/i);
+  if (projectUrlMatch) {
+    return {
+      source: "projectUrl",
+      url: projectUrlMatch[1],
+    };
+  }
+
+  return null;
+}
+
+async function fetchNuspecMetadata(
+  packageBaseAddress: string,
+  packageId: string,
+  version: string,
+): Promise<NuGetMetadataCandidate | null> {
+  const packageLower = packageId.toLowerCase();
+  const versionLower = version.toLowerCase();
+  const nuspecUrl = joinUrl(
+    packageBaseAddress,
+    `${packageLower}/${versionLower}/${packageLower}.nuspec`,
+  );
+
+  const response = await fetch(nuspecUrl, {
+    headers: {
+      Accept: "application/xml,text/xml",
+      "User-Agent": "opensrc-cli",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new Error(
+      `Failed to fetch .nuspec metadata: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const xml = await response.text();
+  return extractRepositoryFromNuspecXml(xml);
+}
+
+function normalizeNuGetRepoUrl(rawUrl: string): string | null {
+  let normalized = rawUrl.trim();
+  if (!normalized) return null;
+
+  normalized = normalized
+    .replace(/^git\+/, "")
+    .replace(/^git:\/\//i, "https://")
+    .replace(/^ssh:\/\/git@/i, "https://")
+    .replace(/^git\+ssh:\/\/git@/i, "https://")
+    .replace(/^git@github.com:/i, "https://github.com/")
+    .replace(/\.git$/i, "")
+    .replace(/\/+$/, "");
+
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return null;
+  }
+
+  url.hash = "";
+  url.search = "";
+
+  const host = url.hostname.toLowerCase();
+  if (!ALLOWED_GIT_HOSTS.has(host)) {
+    return null;
+  }
+
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length >= 4 && (parts[2] === "tree" || parts[2] === "blob")) {
+    url.pathname = `/${parts[0]}/${parts[1]}`;
+  }
+
+  const cleanedParts = url.pathname.split("/").filter(Boolean);
+  if (cleanedParts.length !== 2) {
+    return null;
+  }
+
+  cleanedParts[1] = cleanedParts[1].replace(/\.git$/i, "");
+
+  url.pathname = `/${cleanedParts[0]}/${cleanedParts[1]}`;
+  return url.toString().replace(/\/+$/, "");
+}
+
+function getRepositoryCandidate(
+  leafCandidate: NuGetMetadataCandidate | null,
+  nuspecCandidate: NuGetMetadataCandidate | null,
+): NuGetMetadataCandidate | null {
+  if (leafCandidate?.source === "repository") {
+    return leafCandidate;
+  }
+
+  if (nuspecCandidate?.source === "repository") {
+    return nuspecCandidate;
+  }
+
+  if (leafCandidate?.source === "projectUrl") {
+    return leafCandidate;
+  }
+
+  if (nuspecCandidate?.source === "projectUrl") {
+    return nuspecCandidate;
+  }
+
+  return null;
+}
+
+function getPackageLevelFallbackCandidate(
+  leaves: RegistrationLeaf[],
+): NuGetMetadataCandidate | null {
+  for (let i = leaves.length - 1; i >= 0; i -= 1) {
+    const candidate = extractRepositoryFromLeaf(leaves[i]);
+    if (candidate?.source === "repository") {
+      return candidate;
+    }
+  }
+
+  for (let i = leaves.length - 1; i >= 0; i -= 1) {
+    const candidate = extractRepositoryFromLeaf(leaves[i]);
+    if (candidate?.source === "projectUrl") {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse a NuGet package specifier like "Newtonsoft.Json@13.0.3"
+ */
+export function parseNuGetSpec(spec: string): {
+  name: string;
+  version?: string;
+} {
+  const trimmed = spec.trim();
+  const atIndex = trimmed.lastIndexOf("@");
+  if (atIndex > 0) {
+    return {
+      name: trimmed.slice(0, atIndex).trim(),
+      version: trimmed.slice(atIndex + 1).trim(),
+    };
+  }
+
+  return { name: trimmed };
+}
+
+/**
+ * Resolve a NuGet package to its upstream repository information
+ */
+export async function resolveNuGetPackage(
+  packageName: string,
+  version?: string,
+  options: { allowPrerelease?: boolean } = {},
+): Promise<ResolvedPackage> {
+  const { name } = parseNuGetSpec(packageName);
+  if (!name) {
+    throw new Error("NuGet package name is required");
+  }
+
+  const serviceIndex = await fetchJson<NuGetServiceIndex>(NUGET_SERVICE_INDEX);
+  const registrationsBaseUrl = getNuGetResource(
+    serviceIndex,
+    "RegistrationsBaseUrl",
+  );
+  const packageBaseAddress = getNuGetResource(serviceIndex, "PackageBaseAddress");
+
+  const leaves = await fetchRegistrationLeaves(registrationsBaseUrl, name);
+  if (leaves.length === 0) {
+    throw new Error(`Package "${name}" not found on NuGet`);
+  }
+
+  const resolvedVersion = resolveVersionFromLeaves(
+    leaves,
+    name,
+    version,
+    options.allowPrerelease ?? false,
+  );
+  const matchingLeaf = findLeafByVersion(leaves, resolvedVersion);
+
+  if (!matchingLeaf) {
+    throw new Error(
+      `Version "${resolvedVersion}" not found for "${name}" on NuGet`,
+    );
+  }
+
+  const leafCandidate = extractRepositoryFromLeaf(matchingLeaf);
+  const nuspecCandidate =
+    leafCandidate?.source === "repository"
+      ? null
+      : await fetchNuspecMetadata(packageBaseAddress, name, resolvedVersion);
+
+  const candidate = getRepositoryCandidate(leafCandidate, nuspecCandidate);
+  const selectedCandidate = candidate ?? getPackageLevelFallbackCandidate(leaves);
+
+  if (!selectedCandidate) {
+    throw new Error(
+      `No repository metadata found for "${name}@${resolvedVersion}" on NuGet (checked repository and projectUrl fields)`,
+    );
+  }
+
+  const repoUrl = normalizeNuGetRepoUrl(selectedCandidate.url);
+  if (!repoUrl) {
+    throw new Error(
+      `Invalid non-cloneable ${selectedCandidate.source} URL for "${name}@${resolvedVersion}": ${selectedCandidate.url}`,
+    );
+  }
+
+  return {
+    registry: "nuget",
+    name,
+    version: resolvedVersion,
+    repoUrl,
+    gitTag: `v${resolvedVersion}`,
+  };
+}
+
+export const __internal = {
+  normalizeNuGetRepoUrl,
+  extractRepositoryFromNuspecXml,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * Supported package registries
  */
-export type Registry = "npm" | "pypi" | "crates";
+export type Registry = "npm" | "pypi" | "crates" | "nuget";
 
 export interface PackageInfo {
   name: string;
@@ -74,6 +74,7 @@ export interface PackageSpec {
   registry: Registry;
   name: string;
   version?: string;
+  allowPrerelease?: boolean;
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for NuGet packages to the `opensrc` CLI tool, enabling source code fetching, listing, and removal for .NET packages alongside existing npm, PyPI, and crates.io registries. It also introduces command-line options and documentation updates to reflect NuGet support. The most important changes are grouped below:

**NuGet Registry Support**

* Added NuGet registry support throughout the CLI, including fetch, list, and remove commands, and recognized aliases (`dotnet:`, `nupkg:`) for NuGet packages. [[1]](diffhunk://#diff-0b937e75f4c58fe3f8389fdf2479f35bae81968f7a7d1de2f77c883c0bab4b54R88-R110) [[2]](diffhunk://#diff-0b937e75f4c58fe3f8389fdf2479f35bae81968f7a7d1de2f77c883c0bab4b54R132-R138) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R23) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40-R62) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R132) [[6]](diffhunk://#diff-d68fd4fff0a5bd63a705dff54ba268b06fa67232dc1ab57ddc73aeaa19e6a5f1R13) [[7]](diffhunk://#diff-d68fd4fff0a5bd63a705dff54ba268b06fa67232dc1ab57ddc73aeaa19e6a5f1R49-R57) [[8]](diffhunk://#diff-239fcdea566aace0d8f77ba3a3b6486ff1acbcd591f7970734949d4e289833ecL81-R81) [[9]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R98) [[10]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R107-R114) [[11]](diffhunk://#diff-0934bc57e90e3cdeb451404adc0a05618812138242e008be476091e33b0a1662R35)
* Updated CLI program options and help text to include NuGet, and ensured registry detection logic recognizes NuGet and its aliases. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L30-R36) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R98) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R107-R114)

**Command Enhancements**

* Added `--allow-prerelease` option to fetch the latest NuGet package including prerelease versions, wired through CLI and fetch logic. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L30-R36) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L45-R49) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R59) [[4]](diffhunk://#diff-f7a6c5e8dc32796d1139ae4a6cbe6ace0fed36a771897c2a09f912cbb74a343cR38-R39) [[5]](diffhunk://#diff-f7a6c5e8dc32796d1139ae4a6cbe6ace0fed36a771897c2a09f912cbb74a343cR179) [[6]](diffhunk://#diff-f7a6c5e8dc32796d1139ae4a6cbe6ace0fed36a771897c2a09f912cbb74a343cR227) [[7]](diffhunk://#diff-f7a6c5e8dc32796d1139ae4a6cbe6ace0fed36a771897c2a09f912cbb74a343cL356-R362) [[8]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R19-R33)
* Updated the list command to show NuGet packages in their own section, and display NuGet in supported registries when no packages are fetched. [[1]](diffhunk://#diff-d68fd4fff0a5bd63a705dff54ba268b06fa67232dc1ab57ddc73aeaa19e6a5f1R35) [[2]](diffhunk://#diff-d68fd4fff0a5bd63a705dff54ba268b06fa67232dc1ab57ddc73aeaa19e6a5f1R49-R57) [[3]](diffhunk://#diff-8b4c169eecad8c9f492b51baca7f8f1cc22ee7d7eebb25e4c1e2354dd9d426fbR1-R47)
* Modified remove command logic to fall back to NuGet registry if default lookup fails, and added CLI support for removing only NuGet packages. [[1]](diffhunk://#diff-239fcdea566aace0d8f77ba3a3b6486ff1acbcd591f7970734949d4e289833ecL81-R81) [[2]](diffhunk://#diff-42317c47a12b1ba1bbeb3bde96ef0f6a9a1c37d6622e17be6af1b142d055f547R1-R77) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R98) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R107-R114) [[5]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R74-R85)

**Documentation Updates**

* Updated `README.md` and `AGENTS.md` to document NuGet support, CLI usage examples, and registry aliases. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40-R62) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R132) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R23) [[5]](diffhunk://#diff-0934bc57e90e3cdeb451404adc0a05618812138242e008be476091e33b0a1662R35)

**Testing**

* Added and updated tests for NuGet registry detection, CLI routing, fetch, list, and remove commands to ensure NuGet support is robust. [[1]](diffhunk://#diff-8b4c169eecad8c9f492b51baca7f8f1cc22ee7d7eebb25e4c1e2354dd9d426fbR1-R47) [[2]](diffhunk://#diff-42317c47a12b1ba1bbeb3bde96ef0f6a9a1c37d6622e17be6af1b142d055f547R1-R77) [[3]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R9) [[4]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R19-R33) [[5]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R74-R85) [[6]](diffhunk://#diff-0b937e75f4c58fe3f8389fdf2479f35bae81968f7a7d1de2f77c883c0bab4b54R88-R110) [[7]](diffhunk://#diff-0b937e75f4c58fe3f8389fdf2479f35bae81968f7a7d1de2f77c883c0bab4b54R132-R138)

**Path Handling**

* Updated path handling in tests to use `join` for improved cross-platform compatibility. [[1]](diffhunk://#diff-b77768d2e64d4311ebb0bd1477f0b2b33d331d9db78d6dd97aed8011ce8cab75L37-R37) [[2]](diffhunk://#diff-b77768d2e64d4311ebb0bd1477f0b2b33d331d9db78d6dd97aed8011ce8cab75L47-R62)

These changes collectively enable seamless handling of NuGet packages in the `opensrc` tool, making it more useful for .NET developers and teams.