### PR TITLE
feat: add OPENSRC_DISABLE_AGENTS_MD env var to skip AGENTS.md updates

### DIFF
--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -268,6 +268,31 @@ describe("OPENSRC_DISABLE_AGENTS_MD", () => {
       delete process.env.OPENSRC_DISABLE_AGENTS_MD;
     }
   });
+
+  it("updateAgentsMd with empty sources does not touch AGENTS.md when env var is set", async () => {
+    // Pre-create AGENTS.md with opensrc section
+    const pkg = {
+      name: "zod",
+      version: "3.22.0",
+      registry: "npm" as const,
+      path: "repos/github.com/colinhacks/zod",
+      fetchedAt: "2024-01-01T00:00:00.000Z",
+    };
+    await updateAgentsMd({ packages: [pkg], repos: [] }, TEST_DIR);
+    const contentBefore = await readFile(AGENTS_FILE, "utf-8");
+    expect(contentBefore).toContain(SECTION_MARKER);
+
+    process.env.OPENSRC_DISABLE_AGENTS_MD = "1";
+    try {
+      await updateAgentsMd({ packages: [], repos: [] }, TEST_DIR);
+
+      // AGENTS.md should be untouched — section still present
+      const contentAfter = await readFile(AGENTS_FILE, "utf-8");
+      expect(contentAfter).toContain(SECTION_MARKER);
+    } finally {
+      delete process.env.OPENSRC_DISABLE_AGENTS_MD;
+    }
+  });
 });
 
 describe("updateAgentsMd", () => {

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -232,6 +232,44 @@ describe("updatePackageIndex", () => {
   });
 });
 
+describe("OPENSRC_DISABLE_AGENTS_MD", () => {
+  it("ensureAgentsMd returns false without touching file when env var is set", async () => {
+    process.env.OPENSRC_DISABLE_AGENTS_MD = "1";
+    try {
+      const result = await ensureAgentsMd(TEST_DIR);
+      expect(result).toBe(false);
+      expect(existsSync(AGENTS_FILE)).toBe(false);
+    } finally {
+      delete process.env.OPENSRC_DISABLE_AGENTS_MD;
+    }
+  });
+
+  it("updateAgentsMd skips AGENTS.md but still updates sources.json when env var is set", async () => {
+    process.env.OPENSRC_DISABLE_AGENTS_MD = "1";
+    try {
+      const sources = {
+        packages: [
+          {
+            name: "zod",
+            version: "3.22.0",
+            registry: "npm" as const,
+            path: "repos/github.com/colinhacks/zod",
+            fetchedAt: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+        repos: [],
+      };
+
+      await updateAgentsMd(sources, TEST_DIR);
+
+      expect(existsSync(SOURCES_FILE)).toBe(true);
+      expect(existsSync(AGENTS_FILE)).toBe(false);
+    } finally {
+      delete process.env.OPENSRC_DISABLE_AGENTS_MD;
+    }
+  });
+});
+
 describe("updateAgentsMd", () => {
   it("updates both sources.json and AGENTS.md", async () => {
     const sources = {
@@ -278,10 +316,7 @@ describe("updateAgentsMd", () => {
     const contentBefore = await readFile(AGENTS_FILE, "utf-8");
     expect(contentBefore).toContain(SECTION_MARKER);
 
-    const result = await updateAgentsMd(
-      { packages: [], repos: [] },
-      TEST_DIR,
-    );
+    const result = await updateAgentsMd({ packages: [], repos: [] }, TEST_DIR);
     expect(result).toBe(true);
 
     const contentAfter = await readFile(AGENTS_FILE, "utf-8");

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -142,11 +142,22 @@ function extractSection(content: string): string | null {
 }
 
 /**
+ * Check if AGENTS.md updates are disabled via environment variable.
+ * Set OPENSRC_DISABLE_AGENTS_MD=1 to skip all AGENTS.md modifications.
+ */
+function isAgentsMdDisabled(): boolean {
+  return process.env.OPENSRC_DISABLE_AGENTS_MD === "1";
+}
+
+/**
  * Ensure AGENTS.md has the opensrc section (add or update)
  */
 export async function ensureAgentsMd(
   cwd: string = process.cwd(),
 ): Promise<boolean> {
+  if (isAgentsMdDisabled()) {
+    return false;
+  }
   const agentsPath = join(cwd, AGENTS_FILE);
   const newSection = getSectionContent();
 

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -219,6 +219,10 @@ export async function updateAgentsMd(
   // Always update the index file
   await updatePackageIndex(sources, cwd);
 
+  if (isAgentsMdDisabled()) {
+    return false;
+  }
+
   if (sources.packages.length > 0 || sources.repos.length > 0) {
     return ensureAgentsMd(cwd);
   }


### PR DESCRIPTION
Fixes #29

## What this does

Adds `OPENSRC_DISABLE_AGENTS_MD=1` env var to skip all `AGENTS.md` modifications while keeping every other file (`.gitignore`, `tsconfig.json`, `opensrc/sources.json`) working as normal.

Useful for non-interactive workflows — CI pipelines, scripts, or anyone who already maintains their own `AGENTS.md` and doesn't want opensrc touching it.

```bash
# In .zshrc / CI env
export OPENSRC_DISABLE_AGENTS_MD=1

# opensrc will still fetch source, update sources.json, etc.
# but will leave AGENTS.md completely alone
npx opensrc zod
```

## Changes

- `src/lib/agents.ts` — added `isAgentsMdDisabled()` helper + early return in `ensureAgentsMd()` when env var is set
- `src/lib/agents.test.ts` — 2 new test cases covering the env var behaviour

## Testing

Build passes clean, 197 tests passing. The 4 failures in `git.test.ts` are pre-existing Windows path assertions unrelated to this change.

**Build:**

<img width="605" height="83" alt="opensrc-build" src="https://github.com/user-attachments/assets/5fbfcd77-d122-4b7c-8c98-6768c3d99f44" />

**Tests:**

<img width="947" height="165" alt="opensrc-tests" src="https://github.com/user-attachments/assets/21122326-385a-41c5-8dc0-5b179102103f" />
