### PR TITLE
Add homepage field to package.json

### DIFF
--- a/packages/opensrc/package.json
+++ b/packages/opensrc/package.json
@@ -36,5 +36,6 @@
     "ai",
     "coding-agents"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "homepage": "https://opensrc.sh"
 }


### PR DESCRIPTION
Sets homepage to https://opensrc.sh on npm.