### PR TITLE
Prepare v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # opensrc
 
-## 0.7.0
+## 0.7.1
 
 <!-- release:start -->
+### New Features
+
+- **Private repo support** — Authenticate with GitHub and GitLab private repos via `GITHUB_TOKEN` and `GITLAB_TOKEN` environment variables (#38)
+
+### Bug Fixes
+
+- **`remove` command** — Accept the same repo formats as `fetch` (e.g. `github:owner/repo`, full URLs) instead of only `owner/repo` (#39)
+<!-- release:end -->
+
+## 0.7.0
+
 ### New Features
 
 - **Rust rewrite** — Replace the TypeScript CLI with a native Rust binary for ~10x faster startup
@@ -20,7 +31,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.6.0
 

--- a/packages/opensrc/cli/Cargo.lock
+++ b/packages/opensrc/cli/Cargo.lock
@@ -662,7 +662,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opensrc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "clap",

--- a/packages/opensrc/cli/Cargo.toml
+++ b/packages/opensrc/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensrc"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Fetch source code for packages to give coding agents deeper context"
 license = "Apache-2.0"

--- a/packages/opensrc/package.json
+++ b/packages/opensrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensrc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Fetch source code for packages to give coding agents deeper context",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version to 0.7.1
- Sync `Cargo.toml` and `Cargo.lock`
- Add changelog entry

### What's in 0.7.1

- **Private repo support** — `GITHUB_TOKEN` and `GITLAB_TOKEN` for authenticating API calls and git clones (#38)
- **Fix `remove` command** — Accept the same repo formats as `fetch` (#39)