### PR TITLE
feat: add RubyGems registry support

### DIFF
--- a/packages/opensrc/cli/src/commands/list.rs
+++ b/packages/opensrc/cli/src/commands/list.rs
@@ -13,6 +13,7 @@ pub fn run(json: bool) -> Result<(), Box<dyn std::error::Error>> {
         println!("  • npm:      opensrc path zod, opensrc path npm:react");
         println!("  • PyPI:     opensrc path pypi:requests");
         println!("  • crates:   opensrc path crates:serde");
+        println!("  • RubyGems: opensrc path gem:rails");
         return Ok(());
     }
 
@@ -22,7 +23,12 @@ pub fn run(json: bool) -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let registries = [Registry::Npm, Registry::PyPI, Registry::Crates];
+    let registries = [
+        Registry::Npm,
+        Registry::PyPI,
+        Registry::Crates,
+        Registry::RubyGems,
+    ];
     let mut displayed_packages = false;
 
     for registry in &registries {

--- a/packages/opensrc/cli/src/core/registries/mod.rs
+++ b/packages/opensrc/cli/src/core/registries/mod.rs
@@ -2,6 +2,7 @@ pub mod crates;
 pub mod npm;
 pub mod pypi;
 pub mod repo;
+pub mod rubygems;
 
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +13,7 @@ pub enum Registry {
     #[serde(rename = "pypi")]
     PyPI,
     Crates,
+    RubyGems,
 }
 
 impl std::fmt::Display for Registry {
@@ -20,6 +22,7 @@ impl std::fmt::Display for Registry {
             Registry::Npm => write!(f, "npm"),
             Registry::PyPI => write!(f, "pypi"),
             Registry::Crates => write!(f, "crates"),
+            Registry::RubyGems => write!(f, "rubygems"),
         }
     }
 }
@@ -30,6 +33,7 @@ impl Registry {
             Registry::Npm => "npm",
             Registry::PyPI => "PyPI",
             Registry::Crates => "crates.io",
+            Registry::RubyGems => "RubyGems",
         }
     }
 }
@@ -64,6 +68,9 @@ const REGISTRY_PREFIXES: &[(&str, Registry)] = &[
     ("crates:", Registry::Crates),
     ("cargo:", Registry::Crates),
     ("rust:", Registry::Crates),
+    ("gem:", Registry::RubyGems),
+    ("ruby:", Registry::RubyGems),
+    ("rubygems:", Registry::RubyGems),
 ];
 
 pub fn detect_registry(spec: &str) -> DetectedRegistry {
@@ -92,6 +99,7 @@ pub fn parse_package_spec(spec: &str) -> PackageSpec {
         Registry::Npm => npm::parse_npm_spec(&detected.clean_spec),
         Registry::PyPI => pypi::parse_pypi_spec(&detected.clean_spec),
         Registry::Crates => crates::parse_crates_spec(&detected.clean_spec),
+        Registry::RubyGems => rubygems::parse_rubygems_spec(&detected.clean_spec),
     };
 
     PackageSpec {
@@ -106,6 +114,7 @@ pub fn resolve_package(spec: &PackageSpec) -> Result<ResolvedPackage, Box<dyn st
         Registry::Npm => npm::resolve_npm_package(&spec.name, spec.version.as_deref()),
         Registry::PyPI => pypi::resolve_pypi_package(&spec.name, spec.version.as_deref()),
         Registry::Crates => crates::resolve_crate(&spec.name, spec.version.as_deref()),
+        Registry::RubyGems => rubygems::resolve_rubygem(&spec.name, spec.version.as_deref()),
     }
 }
 

--- a/packages/opensrc/cli/src/core/registries/rubygems.rs
+++ b/packages/opensrc/cli/src/core/registries/rubygems.rs
@@ -1,0 +1,119 @@
+use serde::Deserialize;
+
+use super::{is_git_repo_url, normalize_repo_url, Registry, ResolvedPackage};
+
+const RUBYGEMS_API: &str = "https://rubygems.org/api/v1";
+
+#[derive(Deserialize)]
+struct GemInfo {
+    version: String,
+    source_code_uri: Option<String>,
+    homepage_uri: Option<String>,
+}
+
+pub fn parse_rubygems_spec(spec: &str) -> (String, Option<String>) {
+    if let Some(at_idx) = spec.rfind('@') {
+        if at_idx > 0 {
+            return (
+                spec[..at_idx].trim().to_string(),
+                Some(spec[at_idx + 1..].trim().to_string()),
+            );
+        }
+    }
+    (spec.trim().to_string(), None)
+}
+
+fn fetch_gem_info(
+    name: &str,
+    version: Option<&str>,
+) -> Result<GemInfo, Box<dyn std::error::Error>> {
+    let url = match version {
+        Some(v) => format!("https://rubygems.org/api/v2/rubygems/{name}/versions/{v}.json"),
+        None => format!("{RUBYGEMS_API}/gems/{name}.json"),
+    };
+
+    let client = super::http_client();
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .send()?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(format!("Gem \"{name}\" not found on RubyGems").into());
+    }
+    if !resp.status().is_success() {
+        return Err(format!("Failed to fetch gem info: {}", resp.status()).into());
+    }
+
+    Ok(resp.json()?)
+}
+
+fn extract_repo_url(info: &GemInfo) -> Option<String> {
+    // Prefer source_code_uri
+    if let Some(ref url) = info.source_code_uri {
+        if is_git_repo_url(url) {
+            return Some(normalize_repo_url(url));
+        }
+    }
+
+    // Fall back to homepage_uri
+    if let Some(ref url) = info.homepage_uri {
+        if is_git_repo_url(url) {
+            return Some(normalize_repo_url(url));
+        }
+    }
+
+    None
+}
+
+pub fn resolve_rubygem(
+    name: &str,
+    version: Option<&str>,
+) -> Result<ResolvedPackage, Box<dyn std::error::Error>> {
+    let info = fetch_gem_info(name, version)?;
+    let resolved_version = info.version.clone();
+
+    let repo_url = extract_repo_url(&info).ok_or_else(|| {
+        format!(
+            "No repository URL found for \"{name}@{resolved_version}\". \
+             This gem may not have its source code published."
+        )
+    })?;
+
+    let git_tag = format!("v{resolved_version}");
+
+    Ok(ResolvedPackage {
+        registry: Registry::RubyGems,
+        name: name.to_string(),
+        version: resolved_version,
+        repo_url,
+        repo_directory: None,
+        git_tag,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_rubygems_spec_simple() {
+        let (name, version) = parse_rubygems_spec("rails");
+        assert_eq!(name, "rails");
+        assert_eq!(version, None);
+    }
+
+    #[test]
+    fn test_parse_rubygems_spec_with_version() {
+        let (name, version) = parse_rubygems_spec("rails@8.1.3");
+        assert_eq!(name, "rails");
+        assert_eq!(version, Some("8.1.3".into()));
+    }
+
+    #[test]
+    fn test_parse_rubygems_spec_hyphenated() {
+        let (name, version) = parse_rubygems_spec("ruby-openai@7.0.0");
+        assert_eq!(name, "ruby-openai");
+        assert_eq!(version, Some("7.0.0".into()));
+    }
+}

--- a/packages/opensrc/cli/src/main.rs
+++ b/packages/opensrc/cli/src/main.rs
@@ -56,6 +56,9 @@ enum Commands {
         /// Only remove crates.io packages
         #[arg(long)]
         crates: bool,
+        /// Only remove RubyGems packages
+        #[arg(long)]
+        rubygems: bool,
     },
 }
 
@@ -79,6 +82,7 @@ fn main() {
             npm,
             pypi,
             crates,
+            rubygems,
         }) => {
             let registry = if npm {
                 Some(core::registries::Registry::Npm)
@@ -86,6 +90,8 @@ fn main() {
                 Some(core::registries::Registry::PyPI)
             } else if crates {
                 Some(core::registries::Registry::Crates)
+            } else if rubygems {
+                Some(core::registries::Registry::RubyGems)
             } else {
                 None
             };


### PR DESCRIPTION
## Summary

Adds `gem:`, `ruby:`, and `rubygems:` prefixes to fetch Ruby gem source code via rubygems.org API. Follows the existing registry pattern used by npm, PyPI, and crates.io.

## Usage

```bash
opensrc path gem:rails
opensrc path ruby:sidekiq
opensrc path gem:nokogiri@1.16.0
```

Also adds `--rubygems` flag to `opensrc clean` and shows RubyGems in `opensrc list`.

## Demo

![RubyGems demo](https://files.catbox.moe/xsaip9.gif)

## How it works

The rubygems.org API (`/api/v1/gems/{name}.json`) returns `source_code_uri` which maps directly to a git clone URL. Falls back to `homepage_uri` if `source_code_uri` is absent, checking if it points to a known git host. Version-specific lookups use the v2 API (`/api/v2/rubygems/{name}/versions/{version}.json`).

`normalize_repo_url` (already in mod.rs) strips `/tree/vX.Y.Z` suffixes that rubygems.org sometimes appends to source_code_uri.

## Changes

- `rubygems.rs` - New registry module: `parse_rubygems_spec` and `resolve_rubygem` following the existing pattern
- `mod.rs` - Add `RubyGems` variant to `Registry` enum, `gem:`, `ruby:`, `rubygems:` prefixes, extend `parse_package_spec` and `resolve_package`
- `main.rs` - Add `--rubygems` flag to clean command
- `list.rs` - Add RubyGems to the registries display and empty-state help text

## Testing

3 new unit tests covering spec parsing (simple, versioned, hyphenated names). All 35 tests pass with `--test-threads=1`.

```
cargo test --manifest-path packages/opensrc/cli/Cargo.toml -- --test-threads=1
cargo clippy --manifest-path packages/opensrc/cli/Cargo.toml -- -D warnings
cargo fmt --manifest-path packages/opensrc/cli/Cargo.toml --check
```

This contribution was developed with AI assistance (Claude Code).