### PR TITLE
Support Bitbucket Cloud via BITBUCKET_TOKEN and add authentication docs page

### DIFF
--- a/apps/docs/src/app/auth/layout.tsx
+++ b/apps/docs/src/app/auth/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("auth");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/docs/src/app/auth/page.mdx
+++ b/apps/docs/src/app/auth/page.mdx
@@ -1,0 +1,42 @@
+# Authentication
+
+opensrc reads three environment variables to authenticate against private repositories and registry APIs. Set only the ones you need — nothing is persisted, tokens are read from the environment on each run.
+
+Tokens are used for both resolving a repository's default branch (via each host's API) and for the underlying `git clone` over HTTPS.
+
+## GitHub
+
+Set `GITHUB_TOKEN` to a personal access token:
+
+```bash
+export GITHUB_TOKEN=ghp_your_token_here
+opensrc path vercel/private-repo
+```
+
+A fine-grained PAT with **read-only "Contents"** access to the repositories you need, or a classic PAT with the `repo` scope, is sufficient. Setting the token also raises the anonymous GitHub API rate limit from 60 requests/hour to 5,000 requests/hour.
+
+## GitLab
+
+Set `GITLAB_TOKEN` to a personal access token:
+
+```bash
+export GITLAB_TOKEN=glpat_your_token_here
+opensrc path gitlab:group/private-project
+```
+
+The token needs the `read_api` and `read_repository` scopes.
+
+## Bitbucket
+
+Set `BITBUCKET_TOKEN` to a workspace, project, or repository access token:
+
+```bash
+export BITBUCKET_TOKEN=your_access_token
+opensrc path bitbucket:workspace/private-repo
+```
+
+The token needs read access to the repository. Bitbucket Cloud is phasing out app passwords — prefer access tokens for new setups.
+
+## CI and shells
+
+In CI, set the token as a masked secret environment variable. In an interactive shell, export it from your shell profile or a local `.env` that you source on demand. opensrc never writes tokens to disk.

--- a/apps/docs/src/app/registries/page.mdx
+++ b/apps/docs/src/app/registries/page.mdx
@@ -2,6 +2,8 @@
 
 opensrc resolves packages from multiple registries. The registry is detected automatically from the input format.
 
+For private repositories, see [Authentication](/auth).
+
 ## npm
 
 The default registry. Pass a package name directly:

--- a/apps/docs/src/components/docs-mobile-nav.tsx
+++ b/apps/docs/src/components/docs-mobile-nav.tsx
@@ -14,6 +14,7 @@ const nav = [
   { href: "/", label: "Getting Started" },
   { href: "/registries", label: "Registries" },
   { href: "/commands", label: "Commands" },
+  { href: "/auth", label: "Authentication" },
   { href: "/how-it-works", label: "How It Works" },
 ];
 

--- a/apps/docs/src/components/docs-nav.tsx
+++ b/apps/docs/src/components/docs-nav.tsx
@@ -7,6 +7,7 @@ const nav = [
   { href: "/", label: "Getting Started" },
   { href: "/registries", label: "Registries" },
   { href: "/commands", label: "Commands" },
+  { href: "/auth", label: "Authentication" },
   { href: "/how-it-works", label: "How It Works" },
 ];
 

--- a/apps/docs/src/lib/page-titles.ts
+++ b/apps/docs/src/lib/page-titles.ts
@@ -2,6 +2,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "": "Source Code for\nAI Coding Agents",
   registries: "Registries",
   commands: "Commands",
+  auth: "Authentication",
   "how-it-works": "How It Works",
 };
 

--- a/packages/opensrc/README.md
+++ b/packages/opensrc/README.md
@@ -74,6 +74,7 @@ opensrc clean --crates   # only crates.io packages
 | crates.io | `crates:`, `cargo:`, `rust:` | `opensrc path crates:serde` |
 | GitHub | `owner/repo` or URL | `opensrc path vercel/next.js` |
 | GitLab | `gitlab:` or URL | `opensrc path gitlab:owner/repo` |
+| Bitbucket | `bitbucket:` or URL | `opensrc path bitbucket:owner/repo` |
 
 ## How It Works
 

--- a/packages/opensrc/cli/src/core/registries/mod.rs
+++ b/packages/opensrc/cli/src/core/registries/mod.rs
@@ -142,6 +142,12 @@ pub(crate) fn gitlab_token() -> Option<String> {
     std::env::var("GITLAB_TOKEN").ok().filter(|t| !t.is_empty())
 }
 
+pub(crate) fn bitbucket_token() -> Option<String> {
+    std::env::var("BITBUCKET_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty())
+}
+
 /// Rewrites an HTTPS clone URL to embed auth credentials when a token is available.
 pub fn authenticated_clone_url(url: &str) -> String {
     if let Some(token) = github_token() {
@@ -158,6 +164,15 @@ pub fn authenticated_clone_url(url: &str) -> String {
             return url.replacen(
                 "https://gitlab.com",
                 &format!("https://oauth2:{token}@gitlab.com"),
+                1,
+            );
+        }
+    }
+    if let Some(token) = bitbucket_token() {
+        if url.contains("bitbucket.org") {
+            return url.replacen(
+                "https://bitbucket.org",
+                &format!("https://x-token-auth:{token}@bitbucket.org"),
                 1,
             );
         }

--- a/packages/opensrc/cli/src/core/registries/repo.rs
+++ b/packages/opensrc/cli/src/core/registries/repo.rs
@@ -166,10 +166,21 @@ struct GitLabApiResponse {
     default_branch: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct BitbucketMainBranch {
+    name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BitbucketApiResponse {
+    mainbranch: Option<BitbucketMainBranch>,
+}
+
 pub fn resolve_repo(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::Error>> {
     match spec.host.as_str() {
         "github.com" => resolve_github(spec),
         "gitlab.com" => resolve_gitlab(spec),
+        "bitbucket.org" => resolve_bitbucket(spec),
         _ => Ok(ResolvedRepo {
             git_ref: spec.git_ref.clone().unwrap_or_else(|| "main".to_string()),
             repo_url: format!("https://{}/{}/{}", spec.host, spec.owner, spec.repo),
@@ -264,6 +275,65 @@ fn resolve_gitlab(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::E
     })
 }
 
+fn resolve_bitbucket(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::Error>> {
+    let url = format!(
+        "https://api.bitbucket.org/2.0/repositories/{}/{}",
+        spec.owner, spec.repo
+    );
+
+    let client = super::http_client();
+    let mut req = client.get(&url);
+
+    if let Some(token) = super::bitbucket_token() {
+        req = req.header("Authorization", format!("Bearer {token}"));
+    }
+
+    let resp = req.send()?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        let hint = if super::bitbucket_token().is_none() {
+            " If this is a private repo, set BITBUCKET_TOKEN."
+        } else {
+            " Your token may lack access to this repository."
+        };
+        return Err(format!(
+            "Repository \"{}/{}\" not found on Bitbucket.{hint}",
+            spec.owner, spec.repo
+        )
+        .into());
+    }
+    if resp.status() == reqwest::StatusCode::UNAUTHORIZED
+        || resp.status() == reqwest::StatusCode::FORBIDDEN
+    {
+        let hint = if super::bitbucket_token().is_none() {
+            " If this is a private repo, set BITBUCKET_TOKEN."
+        } else {
+            " Your token may lack access to this repository."
+        };
+        return Err(format!(
+            "Access denied to Bitbucket repository \"{}/{}\".{hint}",
+            spec.owner, spec.repo
+        )
+        .into());
+    }
+    if !resp.status().is_success() {
+        return Err(format!("Failed to fetch repository info: {}", resp.status()).into());
+    }
+
+    let data: BitbucketApiResponse = resp.json()?;
+    let resolved_ref = spec.git_ref.clone().unwrap_or_else(|| {
+        data.mainbranch
+            .and_then(|b| b.name)
+            .unwrap_or_else(|| "main".to_string())
+    });
+
+    Ok(ResolvedRepo {
+        git_ref: resolved_ref,
+        repo_url: format!("https://bitbucket.org/{}/{}", spec.owner, spec.repo),
+        display_name: format!("{}/{}/{}", spec.host, spec.owner, spec.repo),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,10 +372,41 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_repo_spec_bitbucket_prefix() {
+        let spec = parse_repo_spec("bitbucket:atlassian/python-bitbucket").unwrap();
+        assert_eq!(spec.host, "bitbucket.org");
+        assert_eq!(spec.owner, "atlassian");
+        assert_eq!(spec.repo, "python-bitbucket");
+        assert_eq!(spec.git_ref, None);
+    }
+
+    #[test]
+    fn test_parse_repo_spec_bitbucket_prefix_with_ref() {
+        let spec = parse_repo_spec("bitbucket:atlassian/python-bitbucket@master").unwrap();
+        assert_eq!(spec.host, "bitbucket.org");
+        assert_eq!(spec.owner, "atlassian");
+        assert_eq!(spec.repo, "python-bitbucket");
+        assert_eq!(spec.git_ref, Some("master".into()));
+    }
+
+    #[test]
+    fn test_parse_repo_spec_bitbucket_url() {
+        let spec = parse_repo_spec("https://bitbucket.org/atlassian/python-bitbucket").unwrap();
+        assert_eq!(spec.host, "bitbucket.org");
+        assert_eq!(spec.owner, "atlassian");
+        assert_eq!(spec.repo, "python-bitbucket");
+        assert_eq!(spec.git_ref, None);
+    }
+
+    #[test]
     fn test_is_repo_spec() {
         assert!(is_repo_spec("vercel/next.js"));
         assert!(is_repo_spec("github:vercel/next.js"));
         assert!(is_repo_spec("https://github.com/vercel/next.js"));
+        assert!(is_repo_spec("bitbucket:atlassian/python-bitbucket"));
+        assert!(is_repo_spec(
+            "https://bitbucket.org/atlassian/python-bitbucket"
+        ));
         assert!(!is_repo_spec("@babel/core"));
         assert!(!is_repo_spec("zod"));
     }


### PR DESCRIPTION
## Summary

- Resolve Bitbucket repos through `api.bitbucket.org/2.0` so the default branch is detected (via `mainbranch.name`) instead of blindly guessing `main`. 404/401/403 surface a hint to set `BITBUCKET_TOKEN` for private repos, matching the GitHub/GitLab pattern.
- Add `BITBUCKET_TOKEN` support: a `bitbucket_token()` helper, Bearer auth on API requests, and `authenticated_clone_url` rewriting `https://bitbucket.org` to `https://x-token-auth:<token>@bitbucket.org`.
- Add a Bitbucket row to the supported registries table in the CLI README.
- Add a dedicated `/auth` docs page documenting all three env vars (`GITHUB_TOKEN`, `GITLAB_TOKEN`, `BITBUCKET_TOKEN`), register it in `PAGE_TITLES`, link it from both sidebar navs, and cross-link from the Registries page.