### PR TITLE
Prepare v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # opensrc
 
-## 0.7.1
+## 0.7.2
 
 <!-- release:start -->
+### New Features
+
+- **`opensrc fetch` subcommand** — Cache a package's source without printing paths, for use in scripts and CI where you just want the source downloaded (#53)
+- **Bitbucket Cloud support** — Fetch source from Bitbucket repos, with private repo authentication via `BITBUCKET_TOKEN` (#52)
+- **Authentication docs** — New docs page covering private repo authentication across GitHub, GitLab, and Bitbucket (#52)
+
+### Improvements
+
+- **Lockfile parsers** — Rewrite lockfile parsers with proper transitive dependency resolution for pnpm workspaces (#51)
+- **Skills location** — Move agent skill to a top-level `skills/` directory for easier discovery (#46)
+- **Docs favicon** — Add favicon to the docs site (#50)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.7.1
+
 ### New Features
 
 - **Private repo support** — Authenticate with GitHub and GitLab private repos via `GITHUB_TOKEN` and `GITLAB_TOKEN` environment variables (#38)
@@ -10,7 +29,6 @@
 ### Bug Fixes
 
 - **`remove` command** — Accept the same repo formats as `fetch` (e.g. `github:owner/repo`, full URLs) instead of only `owner/repo` (#39)
-<!-- release:end -->
 
 ## 0.7.0
 

--- a/packages/opensrc/cli/Cargo.lock
+++ b/packages/opensrc/cli/Cargo.lock
@@ -662,7 +662,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opensrc"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "clap",

--- a/packages/opensrc/cli/Cargo.toml
+++ b/packages/opensrc/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensrc"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Fetch source code for packages to give coding agents deeper context"
 license = "Apache-2.0"

--- a/packages/opensrc/package.json
+++ b/packages/opensrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensrc",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Fetch source code for packages to give coding agents deeper context",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps version to 0.7.2 and adds the changelog entry.

### New Features

- `opensrc fetch` subcommand to cache source without printing paths (#53)
- Bitbucket Cloud support with `BITBUCKET_TOKEN` auth and new authentication docs page (#52)

### Improvements

- Rewrote lockfile parsers with transitive pnpm resolution (#51)
- Moved agent skill to top-level `skills/` directory (#46)
- Added favicon to docs site (#50)