### PR TITLE
Document fetch command, fix search index, add type-check CI, structured error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,7 @@ jobs:
       - name: Build docs
         run: pnpm build
         working-directory: apps/docs
+
+      - name: Type check docs
+        run: pnpm type-check
+        working-directory: apps/docs

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -1,5 +1,21 @@
 # Commands
 
+## fetch
+
+Fetch source code for one or more packages or repos into the cache. Unlike `path`, this command does not print paths — it's designed for pre-populating the cache:
+
+```bash
+opensrc fetch zod
+opensrc fetch pypi:requests crates:serde vercel/next.js
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--cwd <path>` | Working directory for lockfile version resolution |
+| `--quiet` / `-q` | Suppress progress output |
+
 ## path
 
 Print the absolute path to a package's source code, fetching automatically on cache miss. This is the primary command for using opensrc — compose it with any shell tool:

--- a/apps/docs/src/lib/docs-navigation.ts
+++ b/apps/docs/src/lib/docs-navigation.ts
@@ -8,4 +8,5 @@ export const allDocsPages: NavItem[] = [
   { name: "Registries", href: "/registries" },
   { name: "Commands", href: "/commands" },
   { name: "How It Works", href: "/how-it-works" },
+  { name: "Authentication", href: "/auth" },
 ];

--- a/packages/opensrc/README.md
+++ b/packages/opensrc/README.md
@@ -39,6 +39,19 @@ Options:
 - `--cwd <path>` — working directory for lockfile version resolution
 - `--verbose` — show progress during fetch
 
+### Fetch source code
+
+Pre-fetch one or more packages or repos into the cache without printing paths:
+
+```bash
+opensrc fetch zod
+opensrc fetch pypi:requests crates:serde vercel/next.js
+```
+
+Options:
+- `--cwd <path>` — working directory for lockfile version resolution
+- `--quiet` / `-q` — suppress progress output
+
 ### List cached sources
 
 ```bash

--- a/packages/opensrc/cli/Cargo.lock
+++ b/packages/opensrc/cli/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "url",
  "urlencoding",
 ]

--- a/packages/opensrc/cli/Cargo.toml
+++ b/packages/opensrc/cli/Cargo.toml
@@ -18,6 +18,7 @@ dirs = "5.0"
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 url = "2"
+thiserror = "2"
 urlencoding = "2"
 
 [profile.release]

--- a/packages/opensrc/cli/src/commands/clean.rs
+++ b/packages/opensrc/cli/src/commands/clean.rs
@@ -4,17 +4,18 @@ use crate::core::cache::{
     cleanup_empty_dirs, extract_repo_base_path, get_opensrc_dir, get_repos_dir, list_sources,
     write_sources, PackageEntry, RepoEntry,
 };
+use crate::core::error::{Error, Result};
 use crate::core::registries::Registry;
 
 pub fn run(
     clean_packages_flag: bool,
     clean_repos_flag: bool,
     registry: Option<Registry>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<()> {
     let clean_packages = clean_packages_flag || !clean_repos_flag;
     let clean_repos = clean_repos_flag || (!clean_packages_flag && registry.is_none());
 
-    let (packages, repos) = list_sources();
+    let (packages, repos) = list_sources()?;
 
     let mut remaining_packages: Vec<PackageEntry> = packages.clone();
     let mut remaining_repos: Vec<RepoEntry> = repos.clone();
@@ -64,7 +65,7 @@ pub fn run(
 
     let all_paths: std::collections::HashSet<String> =
         pkg_paths.union(&repo_paths).cloned().collect();
-    let opensrc_dir = get_opensrc_dir();
+    let opensrc_dir = get_opensrc_dir()?;
 
     let mut delete_errors = 0usize;
     for repo_path in &all_paths {
@@ -79,7 +80,7 @@ pub fn run(
         }
     }
 
-    let repos_dir = get_repos_dir();
+    let repos_dir = get_repos_dir()?;
     if repos_dir.exists() {
         cleanup_empty_dirs(&repos_dir);
     }
@@ -111,7 +112,9 @@ pub fn run(
     println!("\nCleaned {total} source(s)");
 
     if delete_errors > 0 {
-        return Err(format!("Failed to remove {delete_errors} path(s) from disk").into());
+        return Err(Error::Other(format!(
+            "Failed to remove {delete_errors} path(s) from disk"
+        )));
     }
 
     Ok(())

--- a/packages/opensrc/cli/src/commands/fetch.rs
+++ b/packages/opensrc/cli/src/commands/fetch.rs
@@ -1,10 +1,7 @@
+use crate::core::error::{Error, Result};
 use crate::core::fetcher::ensure_cached;
 
-pub fn run(
-    specs: &[String],
-    cwd: Option<&str>,
-    quiet: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(specs: &[String], cwd: Option<&str>, quiet: bool) -> Result<()> {
     let cwd = cwd.unwrap_or(".");
 
     let mut fetched = 0u32;
@@ -61,7 +58,9 @@ pub fn run(
     }
 
     if had_errors {
-        return Err("Some sources could not be fetched".into());
+        return Err(Error::Other(
+            "Some sources could not be fetched".to_string(),
+        ));
     }
 
     Ok(())

--- a/packages/opensrc/cli/src/commands/list.rs
+++ b/packages/opensrc/cli/src/commands/list.rs
@@ -1,8 +1,9 @@
 use crate::core::cache::{get_absolute_path, list_sources};
+use crate::core::error::Result;
 use crate::core::registries::Registry;
 
-pub fn run(json: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let (packages, repos) = list_sources();
+pub fn run(json: bool) -> Result<()> {
+    let (packages, repos) = list_sources()?;
     let total = packages.len() + repos.len();
 
     if total == 0 {
@@ -17,7 +18,7 @@ pub fn run(json: bool) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if json {
-        let index = crate::core::cache::read_sources();
+        let index = crate::core::cache::read_sources()?;
         println!("{}", serde_json::to_string_pretty(&index)?);
         return Ok(());
     }
@@ -44,7 +45,7 @@ pub fn run(json: bool) -> Result<(), Box<dyn std::error::Error>> {
         for pkg in &pkgs {
             let date = format_date(&pkg.fetched_at);
             println!("  {}@{}", pkg.name, pkg.version);
-            println!("    Path: {}", get_absolute_path(&pkg.path).display());
+            println!("    Path: {}", get_absolute_path(&pkg.path)?.display());
             println!("    Fetched: {date}");
             println!();
         }
@@ -59,7 +60,7 @@ pub fn run(json: bool) -> Result<(), Box<dyn std::error::Error>> {
         for repo in &repos {
             let date = format_date(&repo.fetched_at);
             println!("  {}@{}", repo.name, repo.version);
-            println!("    Path: {}", get_absolute_path(&repo.path).display());
+            println!("    Path: {}", get_absolute_path(&repo.path)?.display());
             println!("    Fetched: {date}");
             println!();
         }

--- a/packages/opensrc/cli/src/commands/path.rs
+++ b/packages/opensrc/cli/src/commands/path.rs
@@ -1,10 +1,7 @@
+use crate::core::error::Result;
 use crate::core::fetcher::ensure_cached;
 
-pub fn run(
-    specs: &[String],
-    cwd: Option<&str>,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(specs: &[String], cwd: Option<&str>, verbose: bool) -> Result<()> {
     let cwd = cwd.unwrap_or(".");
     for spec in specs {
         let outcome = ensure_cached(spec, cwd, verbose)?;

--- a/packages/opensrc/cli/src/commands/remove.rs
+++ b/packages/opensrc/cli/src/commands/remove.rs
@@ -1,10 +1,11 @@
 use crate::core::cache::{
     get_package_info, list_sources, remove_package_source, remove_repo_source, write_sources,
 };
+use crate::core::error::{Error, Result};
 use crate::core::registries::repo::{is_repo_spec, parse_repo_spec};
 use crate::core::registries::{detect_registry, Registry};
 
-pub fn run(items: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(items: &[String]) -> Result<()> {
     let mut removed = 0u32;
     let mut not_found = 0u32;
     let mut had_errors = false;
@@ -45,14 +46,13 @@ pub fn run(items: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             let clean = &detected.clean_spec;
             let mut registry = detected.registry;
 
-            let mut pkg_info = get_package_info(clean, registry);
+            let mut pkg_info = get_package_info(clean, registry)?;
 
-            // Scan other registries if not found
             if pkg_info.is_none() {
                 let registries = [Registry::Npm, Registry::PyPI, Registry::Crates];
                 for reg in &registries {
                     if *reg != registry {
-                        if let Some(info) = get_package_info(clean, *reg) {
+                        if let Some(info) = get_package_info(clean, *reg)? {
                             pkg_info = Some(info);
                             registry = *reg;
                             break;
@@ -96,7 +96,7 @@ pub fn run(items: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     println!("\nRemoved {removed} source(s){nf_msg}");
 
     if removed > 0 {
-        let (packages, repos) = list_sources();
+        let (packages, repos) = list_sources()?;
 
         let remaining_packages: Vec<_> = packages
             .into_iter()
@@ -116,7 +116,7 @@ pub fn run(items: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if had_errors {
-        return Err("Some items could not be removed".into());
+        return Err(Error::Other("Some items could not be removed".to_string()));
     }
 
     Ok(())

--- a/packages/opensrc/cli/src/core/cache.rs
+++ b/packages/opensrc/cli/src/core/cache.rs
@@ -4,6 +4,7 @@ use std::sync::LazyLock;
 
 use serde::{Deserialize, Serialize};
 
+use super::error::{Error, Result};
 use super::registries::Registry;
 
 static RE_HTTPS_REPO: LazyLock<regex::Regex> =
@@ -44,21 +45,17 @@ pub struct SourcesIndex {
     pub repos: Option<Vec<RepoEntry>>,
 }
 
-pub fn get_opensrc_dir() -> PathBuf {
+pub fn get_opensrc_dir() -> Result<PathBuf> {
     if let Ok(home) = std::env::var("OPENSRC_HOME") {
-        return PathBuf::from(home);
+        return Ok(PathBuf::from(home));
     }
-    match dirs::home_dir() {
-        Some(h) => h.join(OPENSRC_DIR),
-        None => {
-            eprintln!("Error: Could not determine home directory. Set the OPENSRC_HOME environment variable.");
-            std::process::exit(1);
-        }
-    }
+    dirs::home_dir()
+        .map(|h| h.join(OPENSRC_DIR))
+        .ok_or(Error::HomeDirNotFound)
 }
 
-pub fn get_repos_dir() -> PathBuf {
-    get_opensrc_dir().join(REPOS_DIR)
+pub fn get_repos_dir() -> Result<PathBuf> {
+    Ok(get_opensrc_dir()?.join(REPOS_DIR))
 }
 
 /// Extract host/owner/repo from a git URL.
@@ -80,26 +77,26 @@ pub fn get_repo_display_name(repo_url: &str) -> Option<String> {
     parse_repo_url(repo_url).map(|(host, owner, repo)| format!("{host}/{owner}/{repo}"))
 }
 
-pub fn get_repo_path(display_name: &str, version: &str) -> PathBuf {
-    get_repos_dir().join(display_name).join(version)
+pub fn get_repo_path(display_name: &str, version: &str) -> Result<PathBuf> {
+    Ok(get_repos_dir()?.join(display_name).join(version))
 }
 
 pub fn get_repo_relative_path(display_name: &str, version: &str) -> String {
     format!("{REPOS_DIR}/{display_name}/{version}")
 }
 
-pub fn get_absolute_path(relative_path: &str) -> PathBuf {
-    get_opensrc_dir().join(relative_path)
+pub fn get_absolute_path(relative_path: &str) -> Result<PathBuf> {
+    Ok(get_opensrc_dir()?.join(relative_path))
 }
 
-pub fn read_sources() -> SourcesIndex {
-    let path = get_opensrc_dir().join(SOURCES_FILE);
+pub fn read_sources() -> Result<SourcesIndex> {
+    let path = get_opensrc_dir()?.join(SOURCES_FILE);
     if !path.exists() {
-        return SourcesIndex::default();
+        return Ok(SourcesIndex::default());
     }
     match fs::read_to_string(&path) {
         Ok(content) => match serde_json::from_str(&content) {
-            Ok(index) => index,
+            Ok(index) => Ok(index),
             Err(e) => {
                 let bak = path.with_extension("json.bak");
                 eprintln!(
@@ -109,25 +106,25 @@ pub fn read_sources() -> SourcesIndex {
                     bak.display()
                 );
                 let _ = fs::copy(&path, &bak);
-                SourcesIndex::default()
+                Ok(SourcesIndex::default())
             }
         },
-        Err(_) => SourcesIndex::default(),
+        Err(_) => Ok(SourcesIndex::default()),
     }
 }
 
-pub fn list_sources() -> (Vec<PackageEntry>, Vec<RepoEntry>) {
-    let index = read_sources();
-    (
+pub fn list_sources() -> Result<(Vec<PackageEntry>, Vec<RepoEntry>)> {
+    let index = read_sources()?;
+    Ok((
         index.packages.unwrap_or_default(),
         index.repos.unwrap_or_default(),
-    )
+    ))
 }
 
 /// Atomic write: serializes to a temp file then renames, so concurrent
 /// readers never see a partially-written sources.json.
-pub fn write_sources(packages: Vec<PackageEntry>, repos: Vec<RepoEntry>) -> std::io::Result<()> {
-    let dir = get_opensrc_dir();
+pub fn write_sources(packages: Vec<PackageEntry>, repos: Vec<RepoEntry>) -> Result<()> {
+    let dir = get_opensrc_dir()?;
     let path = dir.join(SOURCES_FILE);
 
     if packages.is_empty() && repos.is_empty() {
@@ -156,16 +153,16 @@ pub fn write_sources(packages: Vec<PackageEntry>, repos: Vec<RepoEntry>) -> std:
     Ok(())
 }
 
-pub fn get_package_info(name: &str, registry: Registry) -> Option<PackageEntry> {
-    let (packages, _) = list_sources();
-    packages
+pub fn get_package_info(name: &str, registry: Registry) -> Result<Option<PackageEntry>> {
+    let (packages, _) = list_sources()?;
+    Ok(packages
         .into_iter()
-        .find(|p| p.name == name && p.registry == registry)
+        .find(|p| p.name == name && p.registry == registry))
 }
 
-pub fn get_repo_info(display_name: &str) -> Option<RepoEntry> {
-    let (_, repos) = list_sources();
-    repos.into_iter().find(|r| r.name == display_name)
+pub fn get_repo_info(display_name: &str) -> Result<Option<RepoEntry>> {
+    let (_, repos) = list_sources()?;
+    Ok(repos.into_iter().find(|r| r.name == display_name))
 }
 
 pub fn extract_repo_base_path(full_path: &str) -> String {
@@ -177,11 +174,8 @@ pub fn extract_repo_base_path(full_path: &str) -> String {
     }
 }
 
-pub fn remove_package_source(
-    name: &str,
-    registry: Registry,
-) -> Result<(bool, bool), Box<dyn std::error::Error>> {
-    let (packages, _) = list_sources();
+pub fn remove_package_source(name: &str, registry: Registry) -> Result<(bool, bool)> {
+    let (packages, _) = list_sources()?;
     let pkg = match packages
         .iter()
         .find(|p| p.name == name && p.registry == registry)
@@ -203,11 +197,11 @@ pub fn remove_package_source(
         let parts: Vec<&str> = pkg.path.split('/').collect();
         if parts.len() >= 5 && parts[0] == "repos" {
             let versioned = parts[..5].join("/");
-            let versioned_path = get_opensrc_dir().join(&versioned);
+            let versioned_path = get_opensrc_dir()?.join(&versioned);
             if versioned_path.exists() {
                 fs::remove_dir_all(&versioned_path)?;
                 repo_removed = true;
-                cleanup_empty_parent_dirs(&versioned);
+                cleanup_empty_parent_dirs(&versioned)?;
             }
         }
     }
@@ -215,36 +209,33 @@ pub fn remove_package_source(
     Ok((true, repo_removed))
 }
 
-pub fn remove_repo_source(
-    display_name: &str,
-    version: Option<&str>,
-) -> Result<bool, Box<dyn std::error::Error>> {
+pub fn remove_repo_source(display_name: &str, version: Option<&str>) -> Result<bool> {
     if let Some(ver) = version {
-        let path = get_repo_path(display_name, ver);
+        let path = get_repo_path(display_name, ver)?;
         if !path.exists() {
             return Ok(false);
         }
         fs::remove_dir_all(&path)?;
-        cleanup_empty_parent_dirs(&get_repo_relative_path(display_name, ver));
+        cleanup_empty_parent_dirs(&get_repo_relative_path(display_name, ver))?;
         Ok(true)
     } else {
-        let repo_dir = get_repos_dir().join(display_name);
+        let repo_dir = get_repos_dir()?.join(display_name);
         if !repo_dir.exists() {
             return Ok(false);
         }
         fs::remove_dir_all(&repo_dir)?;
-        cleanup_empty_parent_dirs(&format!("{REPOS_DIR}/{display_name}"));
+        cleanup_empty_parent_dirs(&format!("{REPOS_DIR}/{display_name}"))?;
         Ok(true)
     }
 }
 
-fn cleanup_empty_parent_dirs(relative_path: &str) {
+fn cleanup_empty_parent_dirs(relative_path: &str) -> Result<()> {
     let parts: Vec<&str> = relative_path.split('/').collect();
     if parts.len() < 2 {
-        return;
+        return Ok(());
     }
 
-    let base = get_opensrc_dir();
+    let base = get_opensrc_dir()?;
     for i in (1..parts.len()).rev() {
         let dir = base.join(parts[..i].join("/"));
         if dir.exists() {
@@ -257,6 +248,7 @@ fn cleanup_empty_parent_dirs(relative_path: &str) {
             }
         }
     }
+    Ok(())
 }
 
 pub fn cleanup_empty_dirs(dir: &Path) {
@@ -328,7 +320,7 @@ mod tests {
         fs::write(&sources_path, "NOT VALID JSON {{{").unwrap();
 
         std::env::set_var("OPENSRC_HOME", tmp.to_str().unwrap());
-        let index = read_sources();
+        let index = read_sources().unwrap();
         std::env::remove_var("OPENSRC_HOME");
 
         assert!(index.packages.is_none());
@@ -354,7 +346,7 @@ mod tests {
         .unwrap();
 
         std::env::set_var("OPENSRC_HOME", tmp.to_str().unwrap());
-        let index = read_sources();
+        let index = read_sources().unwrap();
         std::env::remove_var("OPENSRC_HOME");
 
         assert!(index.packages.is_some());

--- a/packages/opensrc/cli/src/core/error.rs
+++ b/packages/opensrc/cli/src/core/error.rs
@@ -1,0 +1,46 @@
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Package \"{name}\" not found on {registry}")]
+    PackageNotFound { name: String, registry: String },
+
+    #[error("{0}")]
+    VersionNotFound(String),
+
+    #[error("{0}")]
+    NoRepoUrl(String),
+
+    #[error("{0}")]
+    RepoNotFound(String),
+
+    #[error("{0}")]
+    AccessDenied(String),
+
+    #[error("GitHub API rate limit exceeded. Try again later or set GITHUB_TOKEN.")]
+    RateLimitExceeded,
+
+    #[error("Invalid repository format: {0}")]
+    InvalidRepoSpec(String),
+
+    #[error("{0}")]
+    CloneFailed(String),
+
+    #[error("Could not determine home directory. Set the OPENSRC_HOME environment variable.")]
+    HomeDirNotFound,
+
+    #[error("Failed to fetch {context}: {status}")]
+    HttpStatus { context: String, status: String },
+
+    #[error("{0}")]
+    Other(String),
+
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}

--- a/packages/opensrc/cli/src/core/fetcher.rs
+++ b/packages/opensrc/cli/src/core/fetcher.rs
@@ -4,6 +4,7 @@ use crate::core::cache::{
     get_absolute_path, get_package_info, get_repo_info, list_sources, now_iso, write_sources,
     PackageEntry, RepoEntry,
 };
+use crate::core::error::{Error, Result};
 use crate::core::git::{fetch_repo_source, fetch_source};
 use crate::core::registries::repo::{parse_repo_spec, resolve_repo};
 use crate::core::registries::{
@@ -27,21 +28,17 @@ fn log(verbose: bool, msg: &str) {
     }
 }
 
-fn ensure_package_cached(
-    spec: &str,
-    cwd: &str,
-    verbose: bool,
-) -> Result<FetchOutcome, Box<dyn std::error::Error>> {
+fn ensure_package_cached(spec: &str, cwd: &str, verbose: bool) -> Result<FetchOutcome> {
     let parsed = parse_package_spec(spec);
     let registry = parsed.registry;
     let name = parsed.name.clone();
     let mut version = parsed.version.clone();
 
     if let Some(ref v) = version {
-        if let Some(existing) = get_package_info(&name, registry) {
+        if let Some(existing) = get_package_info(&name, registry)? {
             if existing.version == *v {
                 return Ok(FetchOutcome {
-                    path: get_absolute_path(&existing.path),
+                    path: get_absolute_path(&existing.path)?,
                     name: existing.name,
                     version: existing.version,
                     source_label: registry.label().to_string(),
@@ -56,10 +53,10 @@ fn ensure_package_cached(
         let detected = detect_installed_version(&name, &PathBuf::from(cwd));
         if let Some(v) = detected {
             version = Some(v.clone());
-            if let Some(existing) = get_package_info(&name, registry) {
+            if let Some(existing) = get_package_info(&name, registry)? {
                 if existing.version == v {
                     return Ok(FetchOutcome {
-                        path: get_absolute_path(&existing.path),
+                        path: get_absolute_path(&existing.path)?,
                         name: existing.name,
                         version: existing.version,
                         source_label: registry.label().to_string(),
@@ -84,17 +81,20 @@ fn ensure_package_cached(
     let resolved = resolve_package(&pkg_spec)?;
     log(verbose, &format!("  → Cloning at {}...", resolved.git_tag));
 
-    let result = fetch_source(&resolved);
+    let result = fetch_source(&resolved)?;
 
     if !result.success {
-        return Err(format!("Failed: {}", result.error.as_deref().unwrap_or("unknown")).into());
+        return Err(Error::CloneFailed(format!(
+            "Failed: {}",
+            result.error.as_deref().unwrap_or("unknown")
+        )));
     }
 
     if let Some(ref warn) = result.error {
         log(verbose, &format!("  ⚠ {warn}"));
     }
 
-    let (mut packages, repos) = list_sources();
+    let (mut packages, repos) = list_sources()?;
     let entry = PackageEntry {
         name: result.package.clone(),
         version: result.version.clone(),
@@ -113,7 +113,7 @@ fn ensure_package_cached(
     write_sources(packages, repos)?;
 
     Ok(FetchOutcome {
-        path: get_absolute_path(&result.path),
+        path: get_absolute_path(&result.path)?,
         name: result.package,
         version: result.version,
         source_label: registry.label().to_string(),
@@ -122,24 +122,17 @@ fn ensure_package_cached(
     })
 }
 
-fn ensure_repo_cached(
-    spec: &str,
-    verbose: bool,
-) -> Result<FetchOutcome, Box<dyn std::error::Error>> {
-    let repo_spec = match parse_repo_spec(spec) {
-        Some(s) => s,
-        None => {
-            return Err(format!("Invalid repository format: {spec}").into());
-        }
-    };
+fn ensure_repo_cached(spec: &str, verbose: bool) -> Result<FetchOutcome> {
+    let repo_spec =
+        parse_repo_spec(spec).ok_or_else(|| Error::InvalidRepoSpec(spec.to_string()))?;
 
     let display = format!("{}/{}/{}", repo_spec.host, repo_spec.owner, repo_spec.repo);
 
     if let Some(ref r) = repo_spec.git_ref {
-        if let Some(existing) = get_repo_info(&display) {
+        if let Some(existing) = get_repo_info(&display)? {
             if existing.version == *r {
                 return Ok(FetchOutcome {
-                    path: get_absolute_path(&existing.path),
+                    path: get_absolute_path(&existing.path)?,
                     name: existing.name,
                     version: existing.version,
                     source_label: repo_spec.host.clone(),
@@ -157,17 +150,20 @@ fn ensure_repo_cached(
     let resolved = resolve_repo(&repo_spec)?;
     log(verbose, &format!("  → Cloning at {}...", resolved.git_ref));
 
-    let result = fetch_repo_source(&resolved);
+    let result = fetch_repo_source(&resolved)?;
 
     if !result.success {
-        return Err(format!("Failed: {}", result.error.as_deref().unwrap_or("unknown")).into());
+        return Err(Error::CloneFailed(format!(
+            "Failed: {}",
+            result.error.as_deref().unwrap_or("unknown")
+        )));
     }
 
     if let Some(ref warn) = result.error {
         log(verbose, &format!("  ⚠ {warn}"));
     }
 
-    let (packages, mut repos) = list_sources();
+    let (packages, mut repos) = list_sources()?;
     let entry = RepoEntry {
         name: result.package.clone(),
         version: result.version.clone(),
@@ -182,7 +178,7 @@ fn ensure_repo_cached(
     write_sources(packages, repos)?;
 
     Ok(FetchOutcome {
-        path: get_absolute_path(&result.path),
+        path: get_absolute_path(&result.path)?,
         name: result.package,
         version: result.version,
         source_label: repo_spec.host,
@@ -193,11 +189,7 @@ fn ensure_repo_cached(
 
 /// Ensure the given spec (package or repo) is cached locally, fetching it if
 /// necessary. Returns information about where it ended up on disk.
-pub fn ensure_cached(
-    spec: &str,
-    cwd: &str,
-    verbose: bool,
-) -> Result<FetchOutcome, Box<dyn std::error::Error>> {
+pub fn ensure_cached(spec: &str, cwd: &str, verbose: bool) -> Result<FetchOutcome> {
     if detect_input_type(spec) == "repo" {
         ensure_repo_cached(spec, verbose)
     } else {

--- a/packages/opensrc/cli/src/core/git.rs
+++ b/packages/opensrc/cli/src/core/git.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::process::Command;
 
 use super::cache::{get_repo_display_name, get_repo_path, get_repo_relative_path};
+use super::error::{Error, Result};
 use super::registries::repo::ResolvedRepo;
 use super::registries::{authenticated_clone_url, Registry, ResolvedPackage};
 
@@ -151,39 +152,29 @@ fn remove_git_dir(repo_path: &Path) {
     }
 }
 
-pub fn fetch_source(resolved: &ResolvedPackage) -> FetchResult {
-    let display_name = match get_repo_display_name(&resolved.repo_url) {
-        Some(n) => n,
-        None => {
-            return FetchResult {
-                package: resolved.name.clone(),
-                version: resolved.version.clone(),
-                path: String::new(),
-                success: false,
-                error: Some(format!(
-                    "Could not parse repository URL: {}",
-                    resolved.repo_url
-                )),
-                registry: Some(resolved.registry),
-            }
-        }
-    };
+pub fn fetch_source(resolved: &ResolvedPackage) -> Result<FetchResult> {
+    let display_name = get_repo_display_name(&resolved.repo_url).ok_or_else(|| {
+        Error::Other(format!(
+            "Could not parse repository URL: {}",
+            resolved.repo_url
+        ))
+    })?;
 
-    let repo_path = get_repo_path(&display_name, &resolved.version);
+    let repo_path = get_repo_path(&display_name, &resolved.version)?;
 
     if repo_path.exists() {
         let mut rel = get_repo_relative_path(&display_name, &resolved.version);
         if let Some(ref dir) = resolved.repo_directory {
             rel = format!("{rel}/{dir}");
         }
-        return FetchResult {
+        return Ok(FetchResult {
             package: resolved.name.clone(),
             version: resolved.version.clone(),
             path: rel,
             success: true,
             error: None,
             registry: Some(resolved.registry),
-        };
+        });
     }
 
     if let Some(parent) = repo_path.parent() {
@@ -194,14 +185,14 @@ pub fn fetch_source(resolved: &ResolvedPackage) -> FetchResult {
     let clone = clone_at_tag(&clone_url, &repo_path, &resolved.version);
 
     if !clone.success {
-        return FetchResult {
+        return Ok(FetchResult {
             package: resolved.name.clone(),
             version: resolved.version.clone(),
             path: get_repo_relative_path(&display_name, &resolved.version),
             success: false,
             error: clone.error,
             registry: Some(resolved.registry),
-        };
+        });
     }
 
     remove_git_dir(&repo_path);
@@ -211,28 +202,28 @@ pub fn fetch_source(resolved: &ResolvedPackage) -> FetchResult {
         rel = format!("{rel}/{dir}");
     }
 
-    FetchResult {
+    Ok(FetchResult {
         package: resolved.name.clone(),
         version: resolved.version.clone(),
         path: rel,
         success: true,
         error: clone.error,
         registry: Some(resolved.registry),
-    }
+    })
 }
 
-pub fn fetch_repo_source(resolved: &ResolvedRepo) -> FetchResult {
-    let repo_path = get_repo_path(&resolved.display_name, &resolved.git_ref);
+pub fn fetch_repo_source(resolved: &ResolvedRepo) -> Result<FetchResult> {
+    let repo_path = get_repo_path(&resolved.display_name, &resolved.git_ref)?;
 
     if repo_path.exists() {
-        return FetchResult {
+        return Ok(FetchResult {
             package: resolved.display_name.clone(),
             version: resolved.git_ref.clone(),
             path: get_repo_relative_path(&resolved.display_name, &resolved.git_ref),
             success: true,
             error: None,
             registry: None,
-        };
+        });
     }
 
     if let Some(parent) = repo_path.parent() {
@@ -243,24 +234,24 @@ pub fn fetch_repo_source(resolved: &ResolvedRepo) -> FetchResult {
     let clone = clone_at_ref(&clone_url, &repo_path, &resolved.git_ref);
 
     if !clone.success {
-        return FetchResult {
+        return Ok(FetchResult {
             package: resolved.display_name.clone(),
             version: resolved.git_ref.clone(),
             path: get_repo_relative_path(&resolved.display_name, &resolved.git_ref),
             success: false,
             error: clone.error,
             registry: None,
-        };
+        });
     }
 
     remove_git_dir(&repo_path);
 
-    FetchResult {
+    Ok(FetchResult {
         package: resolved.display_name.clone(),
         version: resolved.git_ref.clone(),
         path: get_repo_relative_path(&resolved.display_name, &resolved.git_ref),
         success: true,
         error: clone.error,
         registry: None,
-    }
+    })
 }

--- a/packages/opensrc/cli/src/core/mod.rs
+++ b/packages/opensrc/cli/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod error;
 pub mod fetcher;
 pub mod git;
 pub mod registries;

--- a/packages/opensrc/cli/src/core/registries/crates.rs
+++ b/packages/opensrc/cli/src/core/registries/crates.rs
@@ -1,5 +1,8 @@
-use super::{Registry, ResolvedPackage};
 use serde::Deserialize;
+
+use crate::core::error::{Error, Result};
+
+use super::{Registry, ResolvedPackage};
 
 const CRATES_API: &str = "https://crates.io/api/v1";
 
@@ -35,7 +38,7 @@ pub fn parse_crates_spec(spec: &str) -> (String, Option<String>) {
     (spec.trim().to_string(), None)
 }
 
-fn fetch_crate_info(name: &str) -> Result<CrateResponse, Box<dyn std::error::Error>> {
+fn fetch_crate_info(name: &str) -> Result<CrateResponse> {
     let url = format!("{CRATES_API}/crates/{name}");
 
     let client = super::http_client();
@@ -45,16 +48,22 @@ fn fetch_crate_info(name: &str) -> Result<CrateResponse, Box<dyn std::error::Err
         .send()?;
 
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        return Err(format!("Crate \"{name}\" not found on crates.io").into());
+        return Err(Error::PackageNotFound {
+            name: name.to_string(),
+            registry: "crates.io".to_string(),
+        });
     }
     if !resp.status().is_success() {
-        return Err(format!("Failed to fetch crate info: {}", resp.status()).into());
+        return Err(Error::HttpStatus {
+            context: "crate info".to_string(),
+            status: resp.status().to_string(),
+        });
     }
 
     Ok(resp.json()?)
 }
 
-fn verify_crate_version(name: &str, version: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn verify_crate_version(name: &str, version: &str) -> Result<()> {
     let url = format!("{CRATES_API}/crates/{name}/{version}");
 
     let client = super::http_client();
@@ -64,13 +73,17 @@ fn verify_crate_version(name: &str, version: &str) -> Result<(), Box<dyn std::er
         .send()?;
 
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        return Err(format!("Version \"{version}\" not found for crate \"{name}\"").into());
+        return Err(Error::VersionNotFound(format!(
+            "Version \"{version}\" not found for crate \"{name}\""
+        )));
     }
     if !resp.status().is_success() {
-        return Err(format!("Failed to fetch crate version info: {}", resp.status()).into());
+        return Err(Error::HttpStatus {
+            context: "crate version info".to_string(),
+            status: resp.status().to_string(),
+        });
     }
 
-    // Just verify it parses; we don't need the data
     let _: CrateVersionResponse = resp.json()?;
     Ok(())
 }
@@ -91,10 +104,7 @@ fn extract_repo_url(krate: &CrateInfo) -> Option<String> {
     None
 }
 
-pub fn resolve_crate(
-    name: &str,
-    version: Option<&str>,
-) -> Result<ResolvedPackage, Box<dyn std::error::Error>> {
+pub fn resolve_crate(name: &str, version: Option<&str>) -> Result<ResolvedPackage> {
     let info = fetch_crate_info(name)?;
 
     let resolved_version = match version {
@@ -106,10 +116,10 @@ pub fn resolve_crate(
     };
 
     let repo_url = extract_repo_url(&info.krate).ok_or_else(|| {
-        format!(
+        Error::NoRepoUrl(format!(
             "No repository URL found for \"{name}@{resolved_version}\". \
              This crate may not have its source published."
-        )
+        ))
     })?;
 
     let git_tag = format!("v{resolved_version}");

--- a/packages/opensrc/cli/src/core/registries/mod.rs
+++ b/packages/opensrc/cli/src/core/registries/mod.rs
@@ -101,7 +101,7 @@ pub fn parse_package_spec(spec: &str) -> PackageSpec {
     }
 }
 
-pub fn resolve_package(spec: &PackageSpec) -> Result<ResolvedPackage, Box<dyn std::error::Error>> {
+pub fn resolve_package(spec: &PackageSpec) -> super::error::Result<ResolvedPackage> {
     match spec.registry {
         Registry::Npm => npm::resolve_npm_package(&spec.name, spec.version.as_deref()),
         Registry::PyPI => pypi::resolve_pypi_package(&spec.name, spec.version.as_deref()),

--- a/packages/opensrc/cli/src/core/registries/npm.rs
+++ b/packages/opensrc/cli/src/core/registries/npm.rs
@@ -3,6 +3,8 @@ use std::sync::LazyLock;
 
 use serde::Deserialize;
 
+use crate::core::error::{Error, Result};
+
 use super::{Registry, ResolvedPackage};
 
 static RE_SCOPED_PKG: LazyLock<regex::Regex> =
@@ -56,7 +58,7 @@ fn npm_registry_url(name: &str) -> String {
     format!("{NPM_REGISTRY}/{encoded}")
 }
 
-fn fetch_npm_info(name: &str) -> Result<NpmResponse, Box<dyn std::error::Error>> {
+fn fetch_npm_info(name: &str) -> Result<NpmResponse> {
     let url = npm_registry_url(name);
 
     let client = super::http_client();
@@ -66,10 +68,16 @@ fn fetch_npm_info(name: &str) -> Result<NpmResponse, Box<dyn std::error::Error>>
         .send()?;
 
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        return Err(format!("Package \"{name}\" not found on npm").into());
+        return Err(Error::PackageNotFound {
+            name: name.to_string(),
+            registry: "npm".to_string(),
+        });
     }
     if !resp.status().is_success() {
-        return Err(format!("Failed to fetch package info: {}", resp.status()).into());
+        return Err(Error::HttpStatus {
+            context: "package info".to_string(),
+            status: resp.status().to_string(),
+        });
     }
 
     Ok(resp.json()?)
@@ -99,10 +107,7 @@ fn extract_repo_url(
     Some((url, repo.directory.clone()))
 }
 
-pub fn resolve_npm_package(
-    name: &str,
-    version: Option<&str>,
-) -> Result<ResolvedPackage, Box<dyn std::error::Error>> {
+pub fn resolve_npm_package(name: &str, version: Option<&str>) -> Result<ResolvedPackage> {
     let info = fetch_npm_info(name)?;
 
     let resolved_version = match version {
@@ -110,7 +115,9 @@ pub fn resolve_npm_package(
         None => info
             .dist_tags
             .get("latest")
-            .ok_or_else(|| format!("No latest version found for \"{name}\""))?
+            .ok_or_else(|| {
+                Error::VersionNotFound(format!("No latest version found for \"{name}\""))
+            })?
             .clone(),
     };
 
@@ -124,10 +131,9 @@ pub fn resolve_npm_package(
             .map(|v| v.as_str())
             .collect();
         let versions_str = tail.into_iter().rev().collect::<Vec<_>>().join(", ");
-        return Err(format!(
+        return Err(Error::VersionNotFound(format!(
             "Version \"{resolved_version}\" not found for \"{name}\". Recent versions: {versions_str}"
-        )
-        .into());
+        )));
     }
 
     let version_info = info.versions.get(&resolved_version);
@@ -136,10 +142,10 @@ pub fn resolve_npm_package(
         version_info.and_then(|v| v.repository.as_ref()),
     )
     .ok_or_else(|| {
-        format!(
+        Error::NoRepoUrl(format!(
             "No repository URL found for \"{name}@{resolved_version}\". \
              This package may not have its source published."
-        )
+        ))
     })?;
 
     let git_tag = format!("v{resolved_version}");

--- a/packages/opensrc/cli/src/core/registries/pypi.rs
+++ b/packages/opensrc/cli/src/core/registries/pypi.rs
@@ -3,6 +3,8 @@ use std::sync::LazyLock;
 
 use serde::Deserialize;
 
+use crate::core::error::{Error, Result};
+
 use super::{Registry, ResolvedPackage};
 
 static RE_PYPI_VERSION: LazyLock<regex::Regex> =
@@ -40,10 +42,7 @@ pub fn parse_pypi_spec(spec: &str) -> (String, Option<String>) {
     (spec.trim().to_string(), None)
 }
 
-fn fetch_pypi_info(
-    name: &str,
-    version: Option<&str>,
-) -> Result<PyPIResponse, Box<dyn std::error::Error>> {
+fn fetch_pypi_info(name: &str, version: Option<&str>) -> Result<PyPIResponse> {
     let url = match version {
         Some(v) => format!("{PYPI_API}/{name}/{v}/json"),
         None => format!("{PYPI_API}/{name}/json"),
@@ -56,10 +55,16 @@ fn fetch_pypi_info(
         .send()?;
 
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        return Err(format!("Package \"{name}\" not found on PyPI").into());
+        return Err(Error::PackageNotFound {
+            name: name.to_string(),
+            registry: "PyPI".to_string(),
+        });
     }
     if !resp.status().is_success() {
-        return Err(format!("Failed to fetch package info: {}", resp.status()).into());
+        return Err(Error::HttpStatus {
+            context: "package info".to_string(),
+            status: resp.status().to_string(),
+        });
     }
 
     Ok(resp.json()?)
@@ -108,18 +113,15 @@ fn extract_repo_url(info: &PyPIInfo) -> Option<String> {
     None
 }
 
-pub fn resolve_pypi_package(
-    name: &str,
-    version: Option<&str>,
-) -> Result<ResolvedPackage, Box<dyn std::error::Error>> {
+pub fn resolve_pypi_package(name: &str, version: Option<&str>) -> Result<ResolvedPackage> {
     let info = fetch_pypi_info(name, version)?;
     let resolved_version = info.info.version.clone();
 
     let repo_url = extract_repo_url(&info.info).ok_or_else(|| {
-        format!(
+        Error::NoRepoUrl(format!(
             "No repository URL found for \"{name}@{resolved_version}\". \
              This package may not have its source published."
-        )
+        ))
     })?;
 
     let git_tag = format!("v{resolved_version}");

--- a/packages/opensrc/cli/src/core/registries/repo.rs
+++ b/packages/opensrc/cli/src/core/registries/repo.rs
@@ -2,6 +2,8 @@ use std::sync::LazyLock;
 
 use serde::Deserialize;
 
+use crate::core::error::{Error, Result};
+
 static RE_URL: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r"^https?://(github\.com|gitlab\.com|bitbucket\.org)/").unwrap()
 });
@@ -176,7 +178,7 @@ struct BitbucketApiResponse {
     mainbranch: Option<BitbucketMainBranch>,
 }
 
-pub fn resolve_repo(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::Error>> {
+pub fn resolve_repo(spec: &RepoSpec) -> Result<ResolvedRepo> {
     match spec.host.as_str() {
         "github.com" => resolve_github(spec),
         "gitlab.com" => resolve_gitlab(spec),
@@ -189,7 +191,7 @@ pub fn resolve_repo(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error:
     }
 }
 
-fn resolve_github(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::Error>> {
+fn resolve_github(spec: &RepoSpec) -> Result<ResolvedRepo> {
     let url = format!("https://api.github.com/repos/{}/{}", spec.owner, spec.repo);
 
     let client = super::http_client();
@@ -209,17 +211,19 @@ fn resolve_github(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::E
         } else {
             " Your token may lack access to this repository."
         };
-        return Err(format!(
+        return Err(Error::RepoNotFound(format!(
             "Repository \"{}/{}\" not found on GitHub.{hint}",
             spec.owner, spec.repo
-        )
-        .into());
+        )));
     }
     if resp.status() == reqwest::StatusCode::FORBIDDEN {
-        return Err("GitHub API rate limit exceeded. Try again later or set GITHUB_TOKEN.".into());
+        return Err(Error::RateLimitExceeded);
     }
     if !resp.status().is_success() {
-        return Err(format!("Failed to fetch repository info: {}", resp.status()).into());
+        return Err(Error::HttpStatus {
+            context: "repository info".to_string(),
+            status: resp.status().to_string(),
+        });
     }
 
     let data: GitHubApiResponse = resp.json()?;
@@ -232,7 +236,7 @@ fn resolve_github(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::E
     })
 }
 
-fn resolve_gitlab(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::Error>> {
+fn resolve_gitlab(spec: &RepoSpec) -> Result<ResolvedRepo> {
     let project_path = format!("{}/{}", spec.owner, spec.repo);
     let encoded = urlencoding::encode(&project_path);
     let url = format!("https://gitlab.com/api/v4/projects/{encoded}");
@@ -252,14 +256,16 @@ fn resolve_gitlab(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::E
         } else {
             " Your token may lack access to this repository."
         };
-        return Err(format!(
+        return Err(Error::RepoNotFound(format!(
             "Repository \"{}/{}\" not found on GitLab.{hint}",
             spec.owner, spec.repo
-        )
-        .into());
+        )));
     }
     if !resp.status().is_success() {
-        return Err(format!("Failed to fetch repository info: {}", resp.status()).into());
+        return Err(Error::HttpStatus {
+            context: "repository info".to_string(),
+            status: resp.status().to_string(),
+        });
     }
 
     let data: GitLabApiResponse = resp.json()?;
@@ -275,7 +281,7 @@ fn resolve_gitlab(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::E
     })
 }
 
-fn resolve_bitbucket(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error::Error>> {
+fn resolve_bitbucket(spec: &RepoSpec) -> Result<ResolvedRepo> {
     let url = format!(
         "https://api.bitbucket.org/2.0/repositories/{}/{}",
         spec.owner, spec.repo
@@ -296,11 +302,10 @@ fn resolve_bitbucket(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error
         } else {
             " Your token may lack access to this repository."
         };
-        return Err(format!(
+        return Err(Error::RepoNotFound(format!(
             "Repository \"{}/{}\" not found on Bitbucket.{hint}",
             spec.owner, spec.repo
-        )
-        .into());
+        )));
     }
     if resp.status() == reqwest::StatusCode::UNAUTHORIZED
         || resp.status() == reqwest::StatusCode::FORBIDDEN
@@ -310,14 +315,16 @@ fn resolve_bitbucket(spec: &RepoSpec) -> Result<ResolvedRepo, Box<dyn std::error
         } else {
             " Your token may lack access to this repository."
         };
-        return Err(format!(
+        return Err(Error::AccessDenied(format!(
             "Access denied to Bitbucket repository \"{}/{}\".{hint}",
             spec.owner, spec.repo
-        )
-        .into());
+        )));
     }
     if !resp.status().is_success() {
-        return Err(format!("Failed to fetch repository info: {}", resp.status()).into());
+        return Err(Error::HttpStatus {
+            context: "repository info".to_string(),
+            status: resp.status().to_string(),
+        });
     }
 
     let data: BitbucketApiResponse = resp.json()?;


### PR DESCRIPTION
## Summary

- **Document `opensrc fetch`** — added to CLI README and docs site commands page (shipped in 0.7.2 but was missing from both)
- **Fix search index** — added `/auth` to `allDocsPages` so the Authentication page is discoverable via site search
- **Add docs type-check to CI** — `pnpm type-check` now runs in the docs CI job
- **Structured error handling** — replaced `Box<dyn std::error::Error>` with a `thiserror`-based `Error` enum across the entire CLI, eliminating the `process::exit(1)` in `get_opensrc_dir()` and giving every error site a typed variant