### PR TITLE
MCP server + improved git tag resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,4 +81,35 @@ rg "pattern" $(opensrc path crates:<package>)
 rg "pattern" $(opensrc path <owner>/<repo>)
 ```
 
+### MCP Server
+
+opensrc can run as an MCP (Model Context Protocol) server, exposing its tools directly to AI agents without shell wrappers.
+
+Start the server:
+
+```bash
+opensrc mcp
+```
+
+Configure in Cursor (`.cursor/mcp.json`) or Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "opensrc": {
+      "command": "opensrc",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Available tools:
+
+- **opensrc_fetch** — Fetch source code for packages into the local cache
+- **opensrc_path** — Get the absolute path to a cached package's source (fetches on cache miss)
+- **opensrc_list** — List all cached sources as JSON
+- **opensrc_remove** — Remove cached source code for specific packages
+- **opensrc_clean** — Remove all cached packages and/or repos
+
 <!-- opensrc:end -->

--- a/packages/opensrc/cli/Cargo.lock
+++ b/packages/opensrc/cli/Cargo.lock
@@ -71,6 +71,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +206,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +290,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -258,10 +324,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -281,8 +369,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -529,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,9 +765,12 @@ dependencies = [
  "dirs",
  "regex",
  "reqwest",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "url",
  "urlencoding",
 ]
@@ -681,6 +780,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -832,6 +937,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +1040,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1128,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1177,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1175,7 +1372,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1185,6 +1394,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1240,7 +1462,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/opensrc/cli/Cargo.toml
+++ b/packages/opensrc/cli/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 url = "2"
 thiserror = "2"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 rmcp = { version = "1.5", features = ["server", "transport-io"] }
 schemars = "1"
 urlencoding = "2"

--- a/packages/opensrc/cli/Cargo.toml
+++ b/packages/opensrc/cli/Cargo.toml
@@ -19,6 +19,9 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 url = "2"
 thiserror = "2"
+tokio = { version = "1", features = ["rt", "macros"] }
+rmcp = { version = "1.5", features = ["server", "transport-io"] }
+schemars = "1"
 urlencoding = "2"
 
 [profile.release]

--- a/packages/opensrc/cli/Cargo.toml
+++ b/packages/opensrc/cli/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 url = "2"
 thiserror = "2"
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 rmcp = { version = "1.5", features = ["server", "transport-io"] }
 schemars = "1"
 urlencoding = "2"

--- a/packages/opensrc/cli/src/core/git.rs
+++ b/packages/opensrc/cli/src/core/git.rs
@@ -34,8 +34,18 @@ fn stderr_string(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stderr).trim().to_string()
 }
 
-fn clone_at_tag(repo_url: &str, target: &Path, version: &str) -> CloneResult {
-    let tags = [format!("v{version}"), version.to_string()];
+fn clone_at_tag(
+    repo_url: &str,
+    target: &Path,
+    version: &str,
+    name: Option<&str>,
+    allow_fallback: bool,
+) -> CloneResult {
+    let mut tags = vec![format!("v{version}"), version.to_string()];
+    if let Some(n) = name {
+        tags.insert(0, format!("{n}@v{version}"));
+        tags.insert(1, format!("{n}@{version}"));
+    }
     let target_str = target.to_string_lossy();
 
     for tag in &tags {
@@ -62,6 +72,16 @@ fn clone_at_tag(repo_url: &str, target: &Path, version: &str) -> CloneResult {
                 continue;
             }
         }
+    }
+
+    if !allow_fallback {
+        let tried = tags.join(", ");
+        return CloneResult {
+            success: false,
+            error: Some(format!(
+                "No git tag found for version {version} (tried: {tried})"
+            )),
+        };
     }
 
     let output = git_clone_output(&["clone", "--depth", "1", repo_url, &target_str]);
@@ -182,7 +202,13 @@ pub fn fetch_source(resolved: &ResolvedPackage) -> Result<FetchResult> {
     }
 
     let clone_url = authenticated_clone_url(&resolved.repo_url);
-    let clone = clone_at_tag(&clone_url, &repo_path, &resolved.version);
+    let clone = clone_at_tag(
+        &clone_url,
+        &repo_path,
+        &resolved.version,
+        Some(&resolved.name),
+        !resolved.version_pinned,
+    );
 
     if !clone.success {
         return Ok(FetchResult {

--- a/packages/opensrc/cli/src/core/registries/crates.rs
+++ b/packages/opensrc/cli/src/core/registries/crates.rs
@@ -131,6 +131,7 @@ pub fn resolve_crate(name: &str, version: Option<&str>) -> Result<ResolvedPackag
         repo_url,
         repo_directory: None,
         git_tag,
+        version_pinned: version.is_some(),
     })
 }
 

--- a/packages/opensrc/cli/src/core/registries/mod.rs
+++ b/packages/opensrc/cli/src/core/registries/mod.rs
@@ -42,6 +42,7 @@ pub struct ResolvedPackage {
     pub repo_url: String,
     pub repo_directory: Option<String>,
     pub git_tag: String,
+    pub version_pinned: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/opensrc/cli/src/core/registries/npm.rs
+++ b/packages/opensrc/cli/src/core/registries/npm.rs
@@ -157,6 +157,7 @@ pub fn resolve_npm_package(name: &str, version: Option<&str>) -> Result<Resolved
         repo_url,
         repo_directory,
         git_tag,
+        version_pinned: version.is_some(),
     })
 }
 

--- a/packages/opensrc/cli/src/core/registries/pypi.rs
+++ b/packages/opensrc/cli/src/core/registries/pypi.rs
@@ -133,6 +133,7 @@ pub fn resolve_pypi_package(name: &str, version: Option<&str>) -> Result<Resolve
         repo_url,
         repo_directory: None,
         git_tag,
+        version_pinned: version.is_some(),
     })
 }
 

--- a/packages/opensrc/cli/src/main.rs
+++ b/packages/opensrc/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod core;
+mod mcp;
 
 use clap::{Parser, Subcommand};
 
@@ -51,6 +52,8 @@ enum Commands {
         #[arg(required = true)]
         packages: Vec<String>,
     },
+    /// Start an MCP (Model Context Protocol) server over stdio
+    Mcp,
     /// Remove all cached packages and/or repos
     Clean {
         /// Only remove packages (all registries)
@@ -90,6 +93,8 @@ fn main() {
         Some(Commands::List { json }) => commands::list::run(json),
 
         Some(Commands::Remove { packages }) => commands::remove::run(&packages),
+
+        Some(Commands::Mcp) => mcp::run(),
 
         Some(Commands::Clean {
             packages,

--- a/packages/opensrc/cli/src/mcp.rs
+++ b/packages/opensrc/cli/src/mcp.rs
@@ -1,0 +1,363 @@
+use std::collections::HashSet;
+use std::fs;
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{schemars, tool, tool_router, ServiceExt};
+use serde::{Deserialize, Serialize};
+
+use crate::core::cache::{
+    cleanup_empty_dirs, extract_repo_base_path, get_opensrc_dir, get_repos_dir,
+    get_package_info, list_sources, read_sources, remove_package_source, remove_repo_source,
+    write_sources, PackageEntry, RepoEntry,
+};
+use crate::core::error::Error;
+use crate::core::fetcher::ensure_cached;
+use crate::core::registries::repo::{is_repo_spec, parse_repo_spec};
+use crate::core::registries::{detect_registry, Registry};
+
+// --- Tool parameter structs ---
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct FetchParams {
+    /// Package or repo specs (e.g. "zod", "pypi:requests", "owner/repo")
+    packages: Vec<String>,
+    /// Working directory for lockfile version resolution
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct PathParams {
+    /// Package or repo spec (e.g. "zod", "pypi:requests", "owner/repo")
+    package: String,
+    /// Working directory for lockfile version resolution
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct RemoveParams {
+    /// Packages or repos to remove from the cache
+    packages: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct CleanParams {
+    /// Only remove packages (not repos). Defaults to removing both.
+    packages: Option<bool>,
+    /// Only remove repos (not packages). Defaults to removing both.
+    repos: Option<bool>,
+    /// Only remove packages from this registry: "npm", "pypi", or "crates"
+    registry: Option<String>,
+}
+
+// --- JSON response helpers ---
+
+#[derive(Serialize)]
+struct FetchResult {
+    name: String,
+    version: String,
+    path: String,
+    from_cache: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FetchError {
+    package: String,
+    error: String,
+}
+
+#[derive(Serialize)]
+struct FetchResponse {
+    results: Vec<FetchResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    errors: Vec<FetchError>,
+}
+
+#[derive(Serialize)]
+struct RemoveResult {
+    removed: u32,
+    not_found: u32,
+    errors: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct CleanResult {
+    packages_removed: usize,
+    repos_removed: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    errors: Vec<String>,
+}
+
+// --- Server ---
+
+#[derive(Clone)]
+pub struct OpensrcServer;
+
+#[tool_router(server_handler)]
+impl OpensrcServer {
+    #[tool(description = "Fetch source code for one or more packages or repos into the local cache. \
+        Accepts npm packages (e.g. \"zod\"), PyPI packages (\"pypi:requests\"), \
+        crates.io packages (\"crates:serde\"), or GitHub repos (\"owner/repo\").")]
+    fn opensrc_fetch(&self, Parameters(params): Parameters<FetchParams>) -> String {
+        let cwd = params.cwd.as_deref().unwrap_or(".");
+        let mut response = FetchResponse {
+            results: Vec::new(),
+            errors: Vec::new(),
+        };
+
+        for spec in &params.packages {
+            match ensure_cached(spec, cwd, false) {
+                Ok(outcome) => {
+                    response.results.push(FetchResult {
+                        name: outcome.name,
+                        version: outcome.version,
+                        path: outcome.path.display().to_string(),
+                        from_cache: outcome.from_cache,
+                        warning: outcome.warning,
+                    });
+                }
+                Err(e) => {
+                    response.errors.push(FetchError {
+                        package: spec.clone(),
+                        error: e.to_string(),
+                    });
+                }
+            }
+        }
+
+        serde_json::to_string_pretty(&response).unwrap_or_else(|e| format!("Error: {e}"))
+    }
+
+    #[tool(description = "Get the absolute path to a cached package's source code. \
+        Fetches on cache miss. Use this path with file-reading tools to explore the source.")]
+    fn opensrc_path(&self, Parameters(params): Parameters<PathParams>) -> String {
+        let cwd = params.cwd.as_deref().unwrap_or(".");
+        match ensure_cached(&params.package, cwd, false) {
+            Ok(outcome) => outcome.path.display().to_string(),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    #[tool(description = "List all cached source code packages and repos. \
+        Returns the full sources index as JSON.")]
+    fn opensrc_list(&self) -> String {
+        match read_sources() {
+            Ok(index) => {
+                serde_json::to_string_pretty(&index).unwrap_or_else(|e| format!("Error: {e}"))
+            }
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    #[tool(description = "Remove cached source code for specific packages or repos.")]
+    fn opensrc_remove(&self, Parameters(params): Parameters<RemoveParams>) -> String {
+        let mut removed = 0u32;
+        let mut not_found = 0u32;
+        let mut errors: Vec<String> = Vec::new();
+        let mut removed_packages: Vec<(String, Registry)> = Vec::new();
+        let mut removed_repos: Vec<String> = Vec::new();
+
+        for item in &params.packages {
+            let is_repo = is_repo_spec(item) || (item.contains('/') && !item.contains(':'));
+
+            if is_repo {
+                let display_name = match parse_repo_spec(item) {
+                    Some(spec) => format!("{}/{}/{}", spec.host, spec.owner, spec.repo),
+                    None => {
+                        errors.push(format!("Could not parse repo spec: {item}"));
+                        continue;
+                    }
+                };
+
+                match remove_repo_source(&display_name, None) {
+                    Ok(true) => {
+                        removed += 1;
+                        removed_repos.push(display_name);
+                    }
+                    Ok(false) => not_found += 1,
+                    Err(e) => errors.push(format!("{item}: {e}")),
+                }
+            } else {
+                let detected = detect_registry(item);
+                let clean = &detected.clean_spec;
+                let mut registry = detected.registry;
+
+                let mut pkg_info = match get_package_info(clean, registry) {
+                    Ok(info) => info,
+                    Err(e) => {
+                        errors.push(format!("{item}: {e}"));
+                        continue;
+                    }
+                };
+
+                if pkg_info.is_none() {
+                    let registries = [Registry::Npm, Registry::PyPI, Registry::Crates];
+                    for reg in &registries {
+                        if *reg != registry {
+                            if let Ok(Some(info)) = get_package_info(clean, *reg) {
+                                pkg_info = Some(info);
+                                registry = *reg;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if pkg_info.is_none() {
+                    not_found += 1;
+                    continue;
+                }
+
+                match remove_package_source(clean, registry) {
+                    Ok((true, _)) => {
+                        removed += 1;
+                        removed_packages.push((clean.clone(), registry));
+                    }
+                    Ok((false, _)) => errors.push(format!("Failed to remove {clean}")),
+                    Err(e) => errors.push(format!("{clean}: {e}")),
+                }
+            }
+        }
+
+        if removed > 0 {
+            if let Ok((packages, repos)) = list_sources() {
+                let remaining_packages: Vec<_> = packages
+                    .into_iter()
+                    .filter(|p| {
+                        !removed_packages
+                            .iter()
+                            .any(|(name, reg)| p.name == *name && p.registry == *reg)
+                    })
+                    .collect();
+                let remaining_repos: Vec<_> = repos
+                    .into_iter()
+                    .filter(|r| !removed_repos.contains(&r.name))
+                    .collect();
+                let _ = write_sources(remaining_packages, remaining_repos);
+            }
+        }
+
+        let result = RemoveResult {
+            removed,
+            not_found,
+            errors,
+        };
+        serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error: {e}"))
+    }
+
+    #[tool(description = "Remove all cached packages and/or repos. \
+        With no arguments, removes everything. Use 'packages' or 'repos' to limit scope, \
+        or 'registry' to target a specific registry (\"npm\", \"pypi\", \"crates\").")]
+    fn opensrc_clean(&self, Parameters(params): Parameters<CleanParams>) -> String {
+        let registry = params.registry.as_deref().and_then(|r| match r {
+            "npm" => Some(Registry::Npm),
+            "pypi" => Some(Registry::PyPI),
+            "crates" => Some(Registry::Crates),
+            _ => None,
+        });
+
+        let clean_packages_flag = params.packages.unwrap_or(false);
+        let clean_repos_flag = params.repos.unwrap_or(false);
+
+        let clean_packages = clean_packages_flag || registry.is_some() || !clean_repos_flag;
+        let clean_repos =
+            clean_repos_flag || (!clean_packages_flag && registry.is_none());
+
+        let (packages, repos) = match list_sources() {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {e}"),
+        };
+
+        let mut remaining_packages: Vec<PackageEntry> = packages.clone();
+        let mut remaining_repos: Vec<RepoEntry> = repos.clone();
+        let mut packages_to_remove: Vec<PackageEntry> = Vec::new();
+        let mut packages_removed = 0usize;
+
+        if clean_packages {
+            if let Some(reg) = registry {
+                packages_to_remove = packages.iter().filter(|p| p.registry == reg).cloned().collect();
+                remaining_packages = packages.iter().filter(|p| p.registry != reg).cloned().collect();
+            } else {
+                packages_to_remove = packages.clone();
+                remaining_packages = Vec::new();
+            }
+            packages_removed = packages_to_remove.len();
+        }
+
+        let mut repos_to_remove: Vec<RepoEntry> = Vec::new();
+        let mut repos_removed = 0usize;
+
+        if clean_repos {
+            repos_to_remove = repos.clone();
+            remaining_repos = Vec::new();
+            repos_removed = repos_to_remove.len();
+        }
+
+        let pkg_paths: HashSet<String> = packages_to_remove
+            .iter()
+            .map(|p| extract_repo_base_path(&p.path))
+            .collect();
+        let repo_paths: HashSet<String> = repos_to_remove.iter().map(|r| r.path.clone()).collect();
+        let needed_paths: HashSet<String> = remaining_packages
+            .iter()
+            .map(|p| extract_repo_base_path(&p.path))
+            .collect();
+        let all_paths: HashSet<String> = pkg_paths.union(&repo_paths).cloned().collect();
+
+        let mut errors: Vec<String> = Vec::new();
+
+        if let Ok(opensrc_dir) = get_opensrc_dir() {
+            for repo_path in &all_paths {
+                if !needed_paths.contains(repo_path) {
+                    let full = opensrc_dir.join(repo_path);
+                    if full.exists() {
+                        if let Err(e) = fs::remove_dir_all(&full) {
+                            errors.push(format!("Failed to remove {}: {e}", full.display()));
+                        }
+                    }
+                }
+            }
+
+            if let Ok(repos_dir) = get_repos_dir() {
+                if repos_dir.exists() {
+                    cleanup_empty_dirs(&repos_dir);
+                }
+            }
+        }
+
+        let total = packages_removed + repos_removed;
+        if total > 0 {
+            let _ = write_sources(remaining_packages, remaining_repos);
+        }
+
+        let result = CleanResult {
+            packages_removed,
+            repos_removed,
+            errors,
+        };
+        serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error: {e}"))
+    }
+}
+
+pub fn run() -> crate::core::error::Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| Error::Other(format!("Failed to create tokio runtime: {e}")))?;
+
+    rt.block_on(async {
+        let transport = rmcp::transport::stdio();
+        let server = OpensrcServer
+            .serve(transport)
+            .await
+            .map_err(|e| Error::Other(format!("MCP server error: {e}")))?;
+
+        server
+            .waiting()
+            .await
+            .map_err(|e| Error::Other(format!("MCP server error: {e}")))?;
+
+        Ok(())
+    })
+}

--- a/packages/opensrc/cli/src/mcp.rs
+++ b/packages/opensrc/cli/src/mcp.rs
@@ -6,9 +6,9 @@ use rmcp::{schemars, tool, tool_router, ServiceExt};
 use serde::{Deserialize, Serialize};
 
 use crate::core::cache::{
-    cleanup_empty_dirs, extract_repo_base_path, get_opensrc_dir, get_repos_dir,
-    get_package_info, list_sources, read_sources, remove_package_source, remove_repo_source,
-    write_sources, PackageEntry, RepoEntry,
+    cleanup_empty_dirs, extract_repo_base_path, get_opensrc_dir, get_package_info, get_repos_dir,
+    list_sources, read_sources, remove_package_source, remove_repo_source, write_sources,
+    PackageEntry, RepoEntry,
 };
 use crate::core::error::Error;
 use crate::core::fetcher::ensure_cached;
@@ -96,9 +96,11 @@ pub struct OpensrcServer;
 
 #[tool_router(server_handler)]
 impl OpensrcServer {
-    #[tool(description = "Fetch source code for one or more packages or repos into the local cache. \
+    #[tool(
+        description = "Fetch source code for one or more packages or repos into the local cache. \
         Accepts npm packages (e.g. \"zod\"), PyPI packages (\"pypi:requests\"), \
-        crates.io packages (\"crates:serde\"), or GitHub repos (\"owner/repo\").")]
+        crates.io packages (\"crates:serde\"), or GitHub repos (\"owner/repo\")."
+    )]
     async fn opensrc_fetch(&self, Parameters(params): Parameters<FetchParams>) -> String {
         let packages = params.packages;
         let cwd = params.cwd.unwrap_or_else(|| ".".to_string());
@@ -135,17 +137,17 @@ impl OpensrcServer {
         .unwrap_or_else(|e| format!("Error: {e}"))
     }
 
-    #[tool(description = "Get the absolute path to a cached package's source code. \
-        Fetches on cache miss. Use this path with file-reading tools to explore the source.")]
+    #[tool(
+        description = "Get the absolute path to a cached package's source code. \
+        Fetches on cache miss. Use this path with file-reading tools to explore the source."
+    )]
     async fn opensrc_path(&self, Parameters(params): Parameters<PathParams>) -> String {
         let package = params.package;
         let cwd = params.cwd.unwrap_or_else(|| ".".to_string());
 
-        tokio::task::spawn_blocking(move || {
-            match ensure_cached(&package, &cwd, false) {
-                Ok(outcome) => outcome.path.display().to_string(),
-                Err(e) => format!("Error: {e}"),
-            }
+        tokio::task::spawn_blocking(move || match ensure_cached(&package, &cwd, false) {
+            Ok(outcome) => outcome.path.display().to_string(),
+            Err(e) => format!("Error: {e}"),
         })
         .await
         .unwrap_or_else(|e| format!("Error: {e}"))
@@ -154,13 +156,11 @@ impl OpensrcServer {
     #[tool(description = "List all cached source code packages and repos. \
         Returns the full sources index as JSON.")]
     async fn opensrc_list(&self) -> String {
-        tokio::task::spawn_blocking(|| {
-            match read_sources() {
-                Ok(index) => {
-                    serde_json::to_string_pretty(&index).unwrap_or_else(|e| format!("Error: {e}"))
-                }
-                Err(e) => format!("Error: {e}"),
+        tokio::task::spawn_blocking(|| match read_sources() {
+            Ok(index) => {
+                serde_json::to_string_pretty(&index).unwrap_or_else(|e| format!("Error: {e}"))
             }
+            Err(e) => format!("Error: {e}"),
         })
         .await
         .unwrap_or_else(|e| format!("Error: {e}"))
@@ -284,8 +284,7 @@ impl OpensrcServer {
             let clean_repos_flag = params.repos.unwrap_or(false);
 
             let clean_packages = clean_packages_flag || registry.is_some() || !clean_repos_flag;
-            let clean_repos =
-                clean_repos_flag || (!clean_packages_flag && registry.is_none());
+            let clean_repos = clean_repos_flag || (!clean_packages_flag && registry.is_none());
 
             let (packages, repos) = match list_sources() {
                 Ok(v) => v,
@@ -299,8 +298,16 @@ impl OpensrcServer {
 
             if clean_packages {
                 if let Some(reg) = registry {
-                    packages_to_remove = packages.iter().filter(|p| p.registry == reg).cloned().collect();
-                    remaining_packages = packages.iter().filter(|p| p.registry != reg).cloned().collect();
+                    packages_to_remove = packages
+                        .iter()
+                        .filter(|p| p.registry == reg)
+                        .cloned()
+                        .collect();
+                    remaining_packages = packages
+                        .iter()
+                        .filter(|p| p.registry != reg)
+                        .cloned()
+                        .collect();
                 } else {
                     packages_to_remove = packages.clone();
                     remaining_packages = Vec::new();
@@ -321,7 +328,8 @@ impl OpensrcServer {
                 .iter()
                 .map(|p| extract_repo_base_path(&p.path))
                 .collect();
-            let repo_paths: HashSet<String> = repos_to_remove.iter().map(|r| r.path.clone()).collect();
+            let repo_paths: HashSet<String> =
+                repos_to_remove.iter().map(|r| r.path.clone()).collect();
             let needed_paths: HashSet<String> = remaining_packages
                 .iter()
                 .map(|p| extract_repo_base_path(&p.path))

--- a/packages/opensrc/cli/src/mcp.rs
+++ b/packages/opensrc/cli/src/mcp.rs
@@ -273,12 +273,17 @@ impl OpensrcServer {
         or 'registry' to target a specific registry (\"npm\", \"pypi\", \"crates\").")]
     async fn opensrc_clean(&self, Parameters(params): Parameters<CleanParams>) -> String {
         tokio::task::spawn_blocking(move || {
-            let registry = params.registry.as_deref().and_then(|r| match r {
-                "npm" => Some(Registry::Npm),
-                "pypi" => Some(Registry::PyPI),
-                "crates" => Some(Registry::Crates),
-                _ => None,
-            });
+            let registry = match params.registry.as_deref() {
+                Some("npm") => Some(Registry::Npm),
+                Some("pypi") => Some(Registry::PyPI),
+                Some("crates") => Some(Registry::Crates),
+                Some(other) => {
+                    return format!(
+                        "Error: unknown registry \"{other}\". Valid options: \"npm\", \"pypi\", \"crates\""
+                    );
+                }
+                None => None,
+            };
 
             let clean_packages_flag = params.packages.unwrap_or(false);
             let clean_repos_flag = params.repos.unwrap_or(false);
@@ -375,7 +380,7 @@ impl OpensrcServer {
 }
 
 pub fn run() -> crate::core::error::Result<()> {
-    let rt = tokio::runtime::Builder::new_multi_thread()
+    let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| Error::Other(format!("Failed to create tokio runtime: {e}")))?;

--- a/packages/opensrc/cli/src/mcp.rs
+++ b/packages/opensrc/cli/src/mcp.rs
@@ -99,249 +99,275 @@ impl OpensrcServer {
     #[tool(description = "Fetch source code for one or more packages or repos into the local cache. \
         Accepts npm packages (e.g. \"zod\"), PyPI packages (\"pypi:requests\"), \
         crates.io packages (\"crates:serde\"), or GitHub repos (\"owner/repo\").")]
-    fn opensrc_fetch(&self, Parameters(params): Parameters<FetchParams>) -> String {
-        let cwd = params.cwd.as_deref().unwrap_or(".");
-        let mut response = FetchResponse {
-            results: Vec::new(),
-            errors: Vec::new(),
-        };
+    async fn opensrc_fetch(&self, Parameters(params): Parameters<FetchParams>) -> String {
+        let packages = params.packages;
+        let cwd = params.cwd.unwrap_or_else(|| ".".to_string());
 
-        for spec in &params.packages {
-            match ensure_cached(spec, cwd, false) {
-                Ok(outcome) => {
-                    response.results.push(FetchResult {
-                        name: outcome.name,
-                        version: outcome.version,
-                        path: outcome.path.display().to_string(),
-                        from_cache: outcome.from_cache,
-                        warning: outcome.warning,
-                    });
-                }
-                Err(e) => {
-                    response.errors.push(FetchError {
-                        package: spec.clone(),
-                        error: e.to_string(),
-                    });
+        tokio::task::spawn_blocking(move || {
+            let mut response = FetchResponse {
+                results: Vec::new(),
+                errors: Vec::new(),
+            };
+
+            for spec in &packages {
+                match ensure_cached(spec, &cwd, false) {
+                    Ok(outcome) => {
+                        response.results.push(FetchResult {
+                            name: outcome.name,
+                            version: outcome.version,
+                            path: outcome.path.display().to_string(),
+                            from_cache: outcome.from_cache,
+                            warning: outcome.warning,
+                        });
+                    }
+                    Err(e) => {
+                        response.errors.push(FetchError {
+                            package: spec.clone(),
+                            error: e.to_string(),
+                        });
+                    }
                 }
             }
-        }
 
-        serde_json::to_string_pretty(&response).unwrap_or_else(|e| format!("Error: {e}"))
+            serde_json::to_string_pretty(&response).unwrap_or_else(|e| format!("Error: {e}"))
+        })
+        .await
+        .unwrap_or_else(|e| format!("Error: {e}"))
     }
 
     #[tool(description = "Get the absolute path to a cached package's source code. \
         Fetches on cache miss. Use this path with file-reading tools to explore the source.")]
-    fn opensrc_path(&self, Parameters(params): Parameters<PathParams>) -> String {
-        let cwd = params.cwd.as_deref().unwrap_or(".");
-        match ensure_cached(&params.package, cwd, false) {
-            Ok(outcome) => outcome.path.display().to_string(),
-            Err(e) => format!("Error: {e}"),
-        }
+    async fn opensrc_path(&self, Parameters(params): Parameters<PathParams>) -> String {
+        let package = params.package;
+        let cwd = params.cwd.unwrap_or_else(|| ".".to_string());
+
+        tokio::task::spawn_blocking(move || {
+            match ensure_cached(&package, &cwd, false) {
+                Ok(outcome) => outcome.path.display().to_string(),
+                Err(e) => format!("Error: {e}"),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| format!("Error: {e}"))
     }
 
     #[tool(description = "List all cached source code packages and repos. \
         Returns the full sources index as JSON.")]
-    fn opensrc_list(&self) -> String {
-        match read_sources() {
-            Ok(index) => {
-                serde_json::to_string_pretty(&index).unwrap_or_else(|e| format!("Error: {e}"))
+    async fn opensrc_list(&self) -> String {
+        tokio::task::spawn_blocking(|| {
+            match read_sources() {
+                Ok(index) => {
+                    serde_json::to_string_pretty(&index).unwrap_or_else(|e| format!("Error: {e}"))
+                }
+                Err(e) => format!("Error: {e}"),
             }
-            Err(e) => format!("Error: {e}"),
-        }
+        })
+        .await
+        .unwrap_or_else(|e| format!("Error: {e}"))
     }
 
     #[tool(description = "Remove cached source code for specific packages or repos.")]
-    fn opensrc_remove(&self, Parameters(params): Parameters<RemoveParams>) -> String {
-        let mut removed = 0u32;
-        let mut not_found = 0u32;
-        let mut errors: Vec<String> = Vec::new();
-        let mut removed_packages: Vec<(String, Registry)> = Vec::new();
-        let mut removed_repos: Vec<String> = Vec::new();
+    async fn opensrc_remove(&self, Parameters(params): Parameters<RemoveParams>) -> String {
+        let packages = params.packages;
 
-        for item in &params.packages {
-            let is_repo = is_repo_spec(item) || (item.contains('/') && !item.contains(':'));
+        tokio::task::spawn_blocking(move || {
+            let mut removed = 0u32;
+            let mut not_found = 0u32;
+            let mut errors: Vec<String> = Vec::new();
+            let mut removed_packages: Vec<(String, Registry)> = Vec::new();
+            let mut removed_repos: Vec<String> = Vec::new();
 
-            if is_repo {
-                let display_name = match parse_repo_spec(item) {
-                    Some(spec) => format!("{}/{}/{}", spec.host, spec.owner, spec.repo),
-                    None => {
-                        errors.push(format!("Could not parse repo spec: {item}"));
-                        continue;
+            for item in &packages {
+                let is_repo = is_repo_spec(item) || (item.contains('/') && !item.contains(':'));
+
+                if is_repo {
+                    let display_name = match parse_repo_spec(item) {
+                        Some(spec) => format!("{}/{}/{}", spec.host, spec.owner, spec.repo),
+                        None => {
+                            errors.push(format!("Could not parse repo spec: {item}"));
+                            continue;
+                        }
+                    };
+
+                    match remove_repo_source(&display_name, None) {
+                        Ok(true) => {
+                            removed += 1;
+                            removed_repos.push(display_name);
+                        }
+                        Ok(false) => not_found += 1,
+                        Err(e) => errors.push(format!("{item}: {e}")),
                     }
-                };
+                } else {
+                    let detected = detect_registry(item);
+                    let clean = &detected.clean_spec;
+                    let mut registry = detected.registry;
 
-                match remove_repo_source(&display_name, None) {
-                    Ok(true) => {
-                        removed += 1;
-                        removed_repos.push(display_name);
-                    }
-                    Ok(false) => not_found += 1,
-                    Err(e) => errors.push(format!("{item}: {e}")),
-                }
-            } else {
-                let detected = detect_registry(item);
-                let clean = &detected.clean_spec;
-                let mut registry = detected.registry;
+                    let mut pkg_info = match get_package_info(clean, registry) {
+                        Ok(info) => info,
+                        Err(e) => {
+                            errors.push(format!("{item}: {e}"));
+                            continue;
+                        }
+                    };
 
-                let mut pkg_info = match get_package_info(clean, registry) {
-                    Ok(info) => info,
-                    Err(e) => {
-                        errors.push(format!("{item}: {e}"));
-                        continue;
-                    }
-                };
-
-                if pkg_info.is_none() {
-                    let registries = [Registry::Npm, Registry::PyPI, Registry::Crates];
-                    for reg in &registries {
-                        if *reg != registry {
-                            if let Ok(Some(info)) = get_package_info(clean, *reg) {
-                                pkg_info = Some(info);
-                                registry = *reg;
-                                break;
+                    if pkg_info.is_none() {
+                        let registries = [Registry::Npm, Registry::PyPI, Registry::Crates];
+                        for reg in &registries {
+                            if *reg != registry {
+                                if let Ok(Some(info)) = get_package_info(clean, *reg) {
+                                    pkg_info = Some(info);
+                                    registry = *reg;
+                                    break;
+                                }
                             }
                         }
                     }
-                }
 
-                if pkg_info.is_none() {
-                    not_found += 1;
-                    continue;
-                }
-
-                match remove_package_source(clean, registry) {
-                    Ok((true, _)) => {
-                        removed += 1;
-                        removed_packages.push((clean.clone(), registry));
+                    if pkg_info.is_none() {
+                        not_found += 1;
+                        continue;
                     }
-                    Ok((false, _)) => errors.push(format!("Failed to remove {clean}")),
-                    Err(e) => errors.push(format!("{clean}: {e}")),
+
+                    match remove_package_source(clean, registry) {
+                        Ok((true, _)) => {
+                            removed += 1;
+                            removed_packages.push((clean.clone(), registry));
+                        }
+                        Ok((false, _)) => errors.push(format!("Failed to remove {clean}")),
+                        Err(e) => errors.push(format!("{clean}: {e}")),
+                    }
                 }
             }
-        }
 
-        if removed > 0 {
-            if let Ok((packages, repos)) = list_sources() {
-                let remaining_packages: Vec<_> = packages
-                    .into_iter()
-                    .filter(|p| {
-                        !removed_packages
-                            .iter()
-                            .any(|(name, reg)| p.name == *name && p.registry == *reg)
-                    })
-                    .collect();
-                let remaining_repos: Vec<_> = repos
-                    .into_iter()
-                    .filter(|r| !removed_repos.contains(&r.name))
-                    .collect();
-                let _ = write_sources(remaining_packages, remaining_repos);
+            if removed > 0 {
+                if let Ok((packages, repos)) = list_sources() {
+                    let remaining_packages: Vec<_> = packages
+                        .into_iter()
+                        .filter(|p| {
+                            !removed_packages
+                                .iter()
+                                .any(|(name, reg)| p.name == *name && p.registry == *reg)
+                        })
+                        .collect();
+                    let remaining_repos: Vec<_> = repos
+                        .into_iter()
+                        .filter(|r| !removed_repos.contains(&r.name))
+                        .collect();
+                    let _ = write_sources(remaining_packages, remaining_repos);
+                }
             }
-        }
 
-        let result = RemoveResult {
-            removed,
-            not_found,
-            errors,
-        };
-        serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error: {e}"))
+            let result = RemoveResult {
+                removed,
+                not_found,
+                errors,
+            };
+            serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error: {e}"))
+        })
+        .await
+        .unwrap_or_else(|e| format!("Error: {e}"))
     }
 
     #[tool(description = "Remove all cached packages and/or repos. \
         With no arguments, removes everything. Use 'packages' or 'repos' to limit scope, \
         or 'registry' to target a specific registry (\"npm\", \"pypi\", \"crates\").")]
-    fn opensrc_clean(&self, Parameters(params): Parameters<CleanParams>) -> String {
-        let registry = params.registry.as_deref().and_then(|r| match r {
-            "npm" => Some(Registry::Npm),
-            "pypi" => Some(Registry::PyPI),
-            "crates" => Some(Registry::Crates),
-            _ => None,
-        });
+    async fn opensrc_clean(&self, Parameters(params): Parameters<CleanParams>) -> String {
+        tokio::task::spawn_blocking(move || {
+            let registry = params.registry.as_deref().and_then(|r| match r {
+                "npm" => Some(Registry::Npm),
+                "pypi" => Some(Registry::PyPI),
+                "crates" => Some(Registry::Crates),
+                _ => None,
+            });
 
-        let clean_packages_flag = params.packages.unwrap_or(false);
-        let clean_repos_flag = params.repos.unwrap_or(false);
+            let clean_packages_flag = params.packages.unwrap_or(false);
+            let clean_repos_flag = params.repos.unwrap_or(false);
 
-        let clean_packages = clean_packages_flag || registry.is_some() || !clean_repos_flag;
-        let clean_repos =
-            clean_repos_flag || (!clean_packages_flag && registry.is_none());
+            let clean_packages = clean_packages_flag || registry.is_some() || !clean_repos_flag;
+            let clean_repos =
+                clean_repos_flag || (!clean_packages_flag && registry.is_none());
 
-        let (packages, repos) = match list_sources() {
-            Ok(v) => v,
-            Err(e) => return format!("Error: {e}"),
-        };
+            let (packages, repos) = match list_sources() {
+                Ok(v) => v,
+                Err(e) => return format!("Error: {e}"),
+            };
 
-        let mut remaining_packages: Vec<PackageEntry> = packages.clone();
-        let mut remaining_repos: Vec<RepoEntry> = repos.clone();
-        let mut packages_to_remove: Vec<PackageEntry> = Vec::new();
-        let mut packages_removed = 0usize;
+            let mut remaining_packages: Vec<PackageEntry> = packages.clone();
+            let mut remaining_repos: Vec<RepoEntry> = repos.clone();
+            let mut packages_to_remove: Vec<PackageEntry> = Vec::new();
+            let mut packages_removed = 0usize;
 
-        if clean_packages {
-            if let Some(reg) = registry {
-                packages_to_remove = packages.iter().filter(|p| p.registry == reg).cloned().collect();
-                remaining_packages = packages.iter().filter(|p| p.registry != reg).cloned().collect();
-            } else {
-                packages_to_remove = packages.clone();
-                remaining_packages = Vec::new();
+            if clean_packages {
+                if let Some(reg) = registry {
+                    packages_to_remove = packages.iter().filter(|p| p.registry == reg).cloned().collect();
+                    remaining_packages = packages.iter().filter(|p| p.registry != reg).cloned().collect();
+                } else {
+                    packages_to_remove = packages.clone();
+                    remaining_packages = Vec::new();
+                }
+                packages_removed = packages_to_remove.len();
             }
-            packages_removed = packages_to_remove.len();
-        }
 
-        let mut repos_to_remove: Vec<RepoEntry> = Vec::new();
-        let mut repos_removed = 0usize;
+            let mut repos_to_remove: Vec<RepoEntry> = Vec::new();
+            let mut repos_removed = 0usize;
 
-        if clean_repos {
-            repos_to_remove = repos.clone();
-            remaining_repos = Vec::new();
-            repos_removed = repos_to_remove.len();
-        }
+            if clean_repos {
+                repos_to_remove = repos.clone();
+                remaining_repos = Vec::new();
+                repos_removed = repos_to_remove.len();
+            }
 
-        let pkg_paths: HashSet<String> = packages_to_remove
-            .iter()
-            .map(|p| extract_repo_base_path(&p.path))
-            .collect();
-        let repo_paths: HashSet<String> = repos_to_remove.iter().map(|r| r.path.clone()).collect();
-        let needed_paths: HashSet<String> = remaining_packages
-            .iter()
-            .map(|p| extract_repo_base_path(&p.path))
-            .collect();
-        let all_paths: HashSet<String> = pkg_paths.union(&repo_paths).cloned().collect();
+            let pkg_paths: HashSet<String> = packages_to_remove
+                .iter()
+                .map(|p| extract_repo_base_path(&p.path))
+                .collect();
+            let repo_paths: HashSet<String> = repos_to_remove.iter().map(|r| r.path.clone()).collect();
+            let needed_paths: HashSet<String> = remaining_packages
+                .iter()
+                .map(|p| extract_repo_base_path(&p.path))
+                .collect();
+            let all_paths: HashSet<String> = pkg_paths.union(&repo_paths).cloned().collect();
 
-        let mut errors: Vec<String> = Vec::new();
+            let mut errors: Vec<String> = Vec::new();
 
-        if let Ok(opensrc_dir) = get_opensrc_dir() {
-            for repo_path in &all_paths {
-                if !needed_paths.contains(repo_path) {
-                    let full = opensrc_dir.join(repo_path);
-                    if full.exists() {
-                        if let Err(e) = fs::remove_dir_all(&full) {
-                            errors.push(format!("Failed to remove {}: {e}", full.display()));
+            if let Ok(opensrc_dir) = get_opensrc_dir() {
+                for repo_path in &all_paths {
+                    if !needed_paths.contains(repo_path) {
+                        let full = opensrc_dir.join(repo_path);
+                        if full.exists() {
+                            if let Err(e) = fs::remove_dir_all(&full) {
+                                errors.push(format!("Failed to remove {}: {e}", full.display()));
+                            }
                         }
+                    }
+                }
+
+                if let Ok(repos_dir) = get_repos_dir() {
+                    if repos_dir.exists() {
+                        cleanup_empty_dirs(&repos_dir);
                     }
                 }
             }
 
-            if let Ok(repos_dir) = get_repos_dir() {
-                if repos_dir.exists() {
-                    cleanup_empty_dirs(&repos_dir);
-                }
+            let total = packages_removed + repos_removed;
+            if total > 0 {
+                let _ = write_sources(remaining_packages, remaining_repos);
             }
-        }
 
-        let total = packages_removed + repos_removed;
-        if total > 0 {
-            let _ = write_sources(remaining_packages, remaining_repos);
-        }
-
-        let result = CleanResult {
-            packages_removed,
-            repos_removed,
-            errors,
-        };
-        serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error: {e}"))
+            let result = CleanResult {
+                packages_removed,
+                repos_removed,
+                errors,
+            };
+            serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error: {e}"))
+        })
+        .await
+        .unwrap_or_else(|e| format!("Error: {e}"))
     }
 }
 
 pub fn run() -> crate::core::error::Result<()> {
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .map_err(|e| Error::Other(format!("Failed to create tokio runtime: {e}")))?;


### PR DESCRIPTION
## Summary

- **MCP server**: Adds `opensrc mcp` subcommand that runs opensrc as an MCP server over stdio using the official Rust SDK (rmcp). Exposes all 5 CLI commands as MCP tools (`opensrc_fetch`, `opensrc_path`, `opensrc_list`, `opensrc_remove`, `opensrc_clean`), so MCP-aware agents (Cursor, Claude Desktop, etc.) can call them directly without shell wrappers.

- **Monorepo tag resolution**: `clone_at_tag` now tries `{name}@v{version}` and `{name}@{version}` patterns before `v{version}` and `{version}`, fixing resolution for monorepo packages like the Vercel AI SDK that use `ai@5.0.0`-style tags.

- **Fail on pinned version miss**: When a version is explicitly requested (e.g. `opensrc fetch ai@5.0.0`) and no matching git tag is found, opensrc now returns an error instead of silently falling back to the default branch. Unpinned versions (resolved via `latest`) retain the fallback behavior.