### PR TITLE
feat(cli): add local cache option

### DIFF
--- a/packages/opensrc/README.md
+++ b/packages/opensrc/README.md
@@ -36,6 +36,7 @@ cat $(opensrc path pypi:flask@3.0.0)/src/flask/app.py
 ```
 
 Options:
+- `--local` — use `.opensrc` inside `--cwd` instead of the global cache
 - `--cwd <path>` — working directory for lockfile version resolution
 - `--verbose` — show progress during fetch
 
@@ -49,8 +50,24 @@ opensrc fetch pypi:requests crates:serde vercel/next.js
 ```
 
 Options:
+- `--local` — use `.opensrc` inside `--cwd` instead of the global cache
 - `--cwd <path>` — working directory for lockfile version resolution
 - `--quiet` / `-q` — suppress progress output
+
+### Local project cache
+
+By default, `opensrc` stores sources globally in `~/.opensrc`. Use `--local` when
+an agent should only see sources cached for the current project:
+
+```bash
+opensrc --local fetch zod
+opensrc --local path --cwd ./apps/web zod
+opensrc --local list
+```
+
+For `fetch` and `path`, `--local` stores sources in `--cwd/.opensrc` when
+`--cwd` is provided, otherwise in `./.opensrc`. For `list`, `remove`, and
+`clean`, it reads from `./.opensrc`.
 
 ### List cached sources
 
@@ -98,6 +115,7 @@ opensrc clean --crates   # only crates.io packages
 5. Tracks metadata in `~/.opensrc/sources.json`
 
 The `OPENSRC_HOME` environment variable overrides the default cache location.
+The `--local` flag overrides both and uses a project-local `.opensrc` directory.
 
 ## Development
 

--- a/packages/opensrc/cli/src/core/cache.rs
+++ b/packages/opensrc/cli/src/core/cache.rs
@@ -54,6 +54,10 @@ pub fn get_opensrc_dir() -> Result<PathBuf> {
         .ok_or(Error::HomeDirNotFound)
 }
 
+pub fn get_local_opensrc_dir(cwd: &str) -> PathBuf {
+    PathBuf::from(cwd).join(OPENSRC_DIR)
+}
+
 pub fn get_repos_dir() -> Result<PathBuf> {
     Ok(get_opensrc_dir()?.join(REPOS_DIR))
 }
@@ -307,6 +311,14 @@ mod tests {
             "repos/github.com/owner/repo".to_string()
         );
         assert_eq!(extract_repo_base_path("other"), "other".to_string());
+    }
+
+    #[test]
+    fn test_get_local_opensrc_dir_uses_cwd() {
+        assert_eq!(
+            get_local_opensrc_dir("/tmp/project"),
+            PathBuf::from("/tmp/project").join(OPENSRC_DIR)
+        );
     }
 
     #[test]

--- a/packages/opensrc/cli/src/main.rs
+++ b/packages/opensrc/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod core;
 
+use crate::core::cache::get_local_opensrc_dir;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -8,6 +9,10 @@ use clap::{Parser, Subcommand};
 #[command(about = "Fetch source code for packages to give coding agents deeper context")]
 #[command(version)]
 struct Cli {
+    /// Store and read the cache from .opensrc in the working directory
+    #[arg(long, global = true)]
+    local: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -38,7 +43,7 @@ enum Commands {
         #[arg(long)]
         verbose: bool,
     },
-    /// List all globally cached sources
+    /// List all cached sources
     List {
         /// Output as JSON
         #[arg(long)]
@@ -79,17 +84,29 @@ fn main() {
             packages,
             cwd,
             quiet,
-        }) => commands::fetch::run(&packages, cwd.as_deref(), quiet),
+        }) => {
+            configure_cache(cli.local, cwd.as_deref());
+            commands::fetch::run(&packages, cwd.as_deref(), quiet)
+        }
 
         Some(Commands::Path {
             packages,
             cwd,
             verbose,
-        }) => commands::path::run(&packages, cwd.as_deref(), verbose),
+        }) => {
+            configure_cache(cli.local, cwd.as_deref());
+            commands::path::run(&packages, cwd.as_deref(), verbose)
+        }
 
-        Some(Commands::List { json }) => commands::list::run(json),
+        Some(Commands::List { json }) => {
+            configure_cache(cli.local, None);
+            commands::list::run(json)
+        }
 
-        Some(Commands::Remove { packages }) => commands::remove::run(&packages),
+        Some(Commands::Remove { packages }) => {
+            configure_cache(cli.local, None);
+            commands::remove::run(&packages)
+        }
 
         Some(Commands::Clean {
             packages,
@@ -98,6 +115,7 @@ fn main() {
             pypi,
             crates,
         }) => {
+            configure_cache(cli.local, None);
             let registry = if npm {
                 Some(core::registries::Registry::Npm)
             } else if pypi {
@@ -120,5 +138,11 @@ fn main() {
     if let Err(e) = result {
         eprintln!("Error: {e}");
         std::process::exit(1);
+    }
+}
+
+fn configure_cache(local: bool, cwd: Option<&str>) {
+    if local {
+        std::env::set_var("OPENSRC_HOME", get_local_opensrc_dir(cwd.unwrap_or(".")));
     }
 }


### PR DESCRIPTION
## Summary

Adds a global `--local` option that makes `opensrc` use a project-local `.opensrc` directory instead of the default global cache.

This addresses the workflow in #45 where agents should read sources scoped to the current working tree rather than searching under the user's home directory.

## Behavior

- `opensrc --local fetch ...` caches under `./.opensrc`
- `opensrc --local path --cwd ./apps/web ...` caches under `./apps/web/.opensrc`
- `opensrc --local list/remove/clean` operate on `./.opensrc`
- Existing default behavior and `OPENSRC_HOME` remain unchanged unless `--local` is explicitly passed

## Validation

- `cargo fmt --manifest-path packages/opensrc/cli/Cargo.toml`
- `cargo test --manifest-path packages/opensrc/cli/Cargo.toml`
- `cargo clippy --manifest-path packages/opensrc/cli/Cargo.toml -- -D warnings`
- `cargo run --manifest-path packages/opensrc/cli/Cargo.toml -- --help`

Closes #45.
