### PR TITLE
feat: add RubyGems registry support

### DIFF
--- a/packages/opensrc/cli/src/commands/list.rs
+++ b/packages/opensrc/cli/src/commands/list.rs
@@ -14,6 +14,7 @@ pub fn run(json: bool) -> Result<()> {
         println!("  • npm:      opensrc fetch zod, opensrc fetch npm:react");
         println!("  • PyPI:     opensrc fetch pypi:requests");
         println!("  • crates:   opensrc fetch crates:serde");
+        println!("  • RubyGems: opensrc fetch gem:rails");
         return Ok(());
     }
 
@@ -23,7 +24,12 @@ pub fn run(json: bool) -> Result<()> {
         return Ok(());
     }
 
-    let registries = [Registry::Npm, Registry::PyPI, Registry::Crates];
+    let registries = [
+        Registry::Npm,
+        Registry::PyPI,
+        Registry::Crates,
+        Registry::RubyGems,
+    ];
     let mut displayed_packages = false;
 
     for registry in &registries {

--- a/packages/opensrc/cli/src/commands/remove.rs
+++ b/packages/opensrc/cli/src/commands/remove.rs
@@ -48,8 +48,16 @@ pub fn run(items: &[String]) -> Result<()> {
 
             let mut pkg_info = get_package_info(clean, registry)?;
 
-            if pkg_info.is_none() {
-                let registries = [Registry::Npm, Registry::PyPI, Registry::Crates];
+            // Only fall back across registries when the user did not supply an
+            // explicit prefix. `opensrc remove gem:rails` must never delete an
+            // npm/PyPI/crates package named `rails`.
+            if pkg_info.is_none() && !detected.was_explicit {
+                let registries = [
+                    Registry::Npm,
+                    Registry::PyPI,
+                    Registry::Crates,
+                    Registry::RubyGems,
+                ];
                 for reg in &registries {
                     if *reg != registry {
                         if let Some(info) = get_package_info(clean, *reg)? {

--- a/packages/opensrc/cli/src/core/registries/mod.rs
+++ b/packages/opensrc/cli/src/core/registries/mod.rs
@@ -2,6 +2,7 @@ pub mod crates;
 pub mod npm;
 pub mod pypi;
 pub mod repo;
+pub mod rubygems;
 
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +13,7 @@ pub enum Registry {
     #[serde(rename = "pypi")]
     PyPI,
     Crates,
+    RubyGems,
 }
 
 impl std::fmt::Display for Registry {
@@ -20,6 +22,7 @@ impl std::fmt::Display for Registry {
             Registry::Npm => write!(f, "npm"),
             Registry::PyPI => write!(f, "pypi"),
             Registry::Crates => write!(f, "crates"),
+            Registry::RubyGems => write!(f, "rubygems"),
         }
     }
 }
@@ -30,6 +33,7 @@ impl Registry {
             Registry::Npm => "npm",
             Registry::PyPI => "PyPI",
             Registry::Crates => "crates.io",
+            Registry::RubyGems => "RubyGems",
         }
     }
 }
@@ -54,6 +58,7 @@ pub struct PackageSpec {
 pub struct DetectedRegistry {
     pub registry: Registry,
     pub clean_spec: String,
+    pub was_explicit: bool,
 }
 
 const REGISTRY_PREFIXES: &[(&str, Registry)] = &[
@@ -64,6 +69,9 @@ const REGISTRY_PREFIXES: &[(&str, Registry)] = &[
     ("crates:", Registry::Crates),
     ("cargo:", Registry::Crates),
     ("rust:", Registry::Crates),
+    ("gem:", Registry::RubyGems),
+    ("ruby:", Registry::RubyGems),
+    ("rubygems:", Registry::RubyGems),
 ];
 
 pub fn detect_registry(spec: &str) -> DetectedRegistry {
@@ -75,6 +83,7 @@ pub fn detect_registry(spec: &str) -> DetectedRegistry {
             return DetectedRegistry {
                 registry,
                 clean_spec: trimmed[prefix.len()..].to_string(),
+                was_explicit: true,
             };
         }
     }
@@ -82,6 +91,7 @@ pub fn detect_registry(spec: &str) -> DetectedRegistry {
     DetectedRegistry {
         registry: Registry::Npm,
         clean_spec: trimmed.to_string(),
+        was_explicit: false,
     }
 }
 
@@ -92,6 +102,7 @@ pub fn parse_package_spec(spec: &str) -> PackageSpec {
         Registry::Npm => npm::parse_npm_spec(&detected.clean_spec),
         Registry::PyPI => pypi::parse_pypi_spec(&detected.clean_spec),
         Registry::Crates => crates::parse_crates_spec(&detected.clean_spec),
+        Registry::RubyGems => rubygems::parse_rubygems_spec(&detected.clean_spec),
     };
 
     PackageSpec {
@@ -106,6 +117,7 @@ pub fn resolve_package(spec: &PackageSpec) -> super::error::Result<ResolvedPacka
         Registry::Npm => npm::resolve_npm_package(&spec.name, spec.version.as_deref()),
         Registry::PyPI => pypi::resolve_pypi_package(&spec.name, spec.version.as_deref()),
         Registry::Crates => crates::resolve_crate(&spec.name, spec.version.as_deref()),
+        Registry::RubyGems => rubygems::resolve_rubygem(&spec.name, spec.version.as_deref()),
     }
 }
 

--- a/packages/opensrc/cli/src/core/registries/rubygems.rs
+++ b/packages/opensrc/cli/src/core/registries/rubygems.rs
@@ -1,0 +1,125 @@
+use serde::Deserialize;
+
+use crate::core::error::{Error, Result};
+
+use super::{is_git_repo_url, normalize_repo_url, Registry, ResolvedPackage};
+
+const RUBYGEMS_API: &str = "https://rubygems.org/api/v1";
+
+#[derive(Deserialize)]
+struct GemInfo {
+    version: String,
+    source_code_uri: Option<String>,
+    homepage_uri: Option<String>,
+}
+
+pub fn parse_rubygems_spec(spec: &str) -> (String, Option<String>) {
+    if let Some(at_idx) = spec.rfind('@') {
+        if at_idx > 0 {
+            return (
+                spec[..at_idx].trim().to_string(),
+                Some(spec[at_idx + 1..].trim().to_string()),
+            );
+        }
+    }
+    (spec.trim().to_string(), None)
+}
+
+fn fetch_gem_info(name: &str, version: Option<&str>) -> Result<GemInfo> {
+    let url = match version {
+        Some(v) => format!("https://rubygems.org/api/v2/rubygems/{name}/versions/{v}.json"),
+        None => format!("{RUBYGEMS_API}/gems/{name}.json"),
+    };
+
+    let client = super::http_client();
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .send()?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        // The v2 endpoint 404s for both "gem does not exist" and "version does
+        // not exist for this gem". Single call can't tell them apart, so the
+        // error reports the user's spec exactly rather than asserting which
+        // piece is missing.
+        let display = match version {
+            Some(v) => format!("{name}@{v}"),
+            None => name.to_string(),
+        };
+        return Err(Error::PackageNotFound {
+            name: display,
+            registry: "RubyGems".to_string(),
+        });
+    }
+    if !resp.status().is_success() {
+        return Err(Error::HttpStatus {
+            context: "gem info".to_string(),
+            status: resp.status().to_string(),
+        });
+    }
+
+    Ok(resp.json()?)
+}
+
+fn extract_repo_url(info: &GemInfo) -> Option<String> {
+    if let Some(ref url) = info.source_code_uri {
+        if is_git_repo_url(url) {
+            return Some(normalize_repo_url(url));
+        }
+    }
+    if let Some(ref url) = info.homepage_uri {
+        if is_git_repo_url(url) {
+            return Some(normalize_repo_url(url));
+        }
+    }
+    None
+}
+
+pub fn resolve_rubygem(name: &str, version: Option<&str>) -> Result<ResolvedPackage> {
+    let info = fetch_gem_info(name, version)?;
+    let resolved_version = info.version.clone();
+
+    let repo_url = extract_repo_url(&info).ok_or_else(|| {
+        Error::NoRepoUrl(format!(
+            "No repository URL found for \"{name}@{resolved_version}\". \
+             This gem may not have its source code published."
+        ))
+    })?;
+
+    let git_tag = format!("v{resolved_version}");
+
+    Ok(ResolvedPackage {
+        registry: Registry::RubyGems,
+        name: name.to_string(),
+        version: resolved_version,
+        repo_url,
+        repo_directory: None,
+        git_tag,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_rubygems_spec_simple() {
+        let (name, version) = parse_rubygems_spec("rails");
+        assert_eq!(name, "rails");
+        assert_eq!(version, None);
+    }
+
+    #[test]
+    fn test_parse_rubygems_spec_with_version() {
+        let (name, version) = parse_rubygems_spec("rails@8.1.3");
+        assert_eq!(name, "rails");
+        assert_eq!(version, Some("8.1.3".into()));
+    }
+
+    #[test]
+    fn test_parse_rubygems_spec_hyphenated() {
+        let (name, version) = parse_rubygems_spec("ruby-openai@7.0.0");
+        assert_eq!(name, "ruby-openai");
+        assert_eq!(version, Some("7.0.0".into()));
+    }
+}

--- a/packages/opensrc/cli/src/main.rs
+++ b/packages/opensrc/cli/src/main.rs
@@ -68,6 +68,9 @@ enum Commands {
         /// Only remove crates.io packages
         #[arg(long)]
         crates: bool,
+        /// Only remove RubyGems packages
+        #[arg(long)]
+        rubygems: bool,
     },
 }
 
@@ -97,6 +100,7 @@ fn main() {
             npm,
             pypi,
             crates,
+            rubygems,
         }) => {
             let registry = if npm {
                 Some(core::registries::Registry::Npm)
@@ -104,6 +108,8 @@ fn main() {
                 Some(core::registries::Registry::PyPI)
             } else if crates {
                 Some(core::registries::Registry::Crates)
+            } else if rubygems {
+                Some(core::registries::Registry::RubyGems)
             } else {
                 None
             };


### PR DESCRIPTION
## Summary

Re-submission of #43 (Matt Van Horn's RubyGems registry support), rebased onto current main with the remove.rs fix the review bot flagged on the original PR, plus two follow-on fixes surfaced during review.

Adds `gem:`, `ruby:`, and `rubygems:` prefixes to fetch Ruby gem source code via rubygems.org API. Same shape as npm, PyPI, and crates.io.

## Usage

```bash
opensrc path gem:rails
opensrc path ruby:sidekiq
opensrc path gem:nokogiri@1.16.0
```

Also adds `--rubygems` to `opensrc clean` and shows RubyGems in `opensrc list`.

## What changed vs #43

- **Rebased onto current main.** #56's structured-error refactor (April 30) replaced `Box<dyn std::error::Error>` with the crate's typed `Error`/`Result` across all registries. `rubygems.rs` now uses `Error::PackageNotFound`, `Error::HttpStatus`, and `Error::NoRepoUrl` to match the other registry modules.
- **Resolved the list.rs conflict** introduced by #53's `opensrc fetch` subcommand. The empty-state hint uses `fetch` examples to match the post-#53 style.
- **Added `Registry::RubyGems` to the fallback registry scan in remove.rs**, the issue the review bot flagged on #43. Without it, RubyGems packages could only be removed by an explicit `gem:` prefix.
- **Tightened the remove.rs prefix scoping.** The cross-registry fallback now only fires when the user did not supply an explicit prefix, so `opensrc remove gem:rails` no longer risks deleting a cached npm/PyPI/crates `rails` when no gem `rails` is present. Added a `was_explicit: bool` field to `DetectedRegistry` to carry the prefix information out of detection.
- **Collapsed the rubygems.rs error variant.** The single-call V2 endpoint can't distinguish "gem missing" from "version missing", so a misleading `VersionNotFound` was replaced with a single `PackageNotFound` reporting the user's spec verbatim.

## Known limitations (out of scope here)

Three concerns surfaced during review that exist in current `main` for every registry, not just RubyGems. Flagging for maintainer visibility; happy to open separate PRs if helpful:

1. **Substring-based host validation.** `is_git_repo_url` in `core/registries/mod.rs` uses `url.contains("github.com")`, and `authenticated_clone_url` rewrites credentials via `str::replace`. A malicious package whose repository URL contains a known host as a substring (e.g. `https://github.com.evil.example/owner/repo`) passes validation and would receive `GITHUB_TOKEN`. Fix: parse with `url::Url` and require exact host match.

2. **Default-branch fallback silently mislabels cache.** `clone_at_tag` in `core/git.rs` treats a tagless default-branch clone as success after `v{version}` and `{version}` both miss. `sources.json` then records the package at the requested version while the cache holds default-branch HEAD. RubyGems is more likely to hit this than npm/crates because gem repos don't uniformly tag with the `v` prefix.

3. **URL encoding inconsistency.** `npm.rs` encodes package names with `urlencoding::encode`; `pypi.rs`, `crates.rs`, and this PR's `rubygems.rs` interpolate raw. Probably benign for the constrained name characters these registries allow, but worth aligning.

## Testing

```
cargo fmt --manifest-path packages/opensrc/cli/Cargo.toml --check
cargo clippy --manifest-path packages/opensrc/cli/Cargo.toml -- -D warnings
cargo test --manifest-path packages/opensrc/cli/Cargo.toml -- --test-threads=1
```

All 107 tests pass. fmt and clippy clean.

## Credit

Original work by @mvanhorn in #43. The squashed commit keeps Matt as Author. I'm listed as Co-author for the rebase, error-pattern port, remove.rs scoping fix, and error-variant collapse.

---

This PR was AI-generated and human-reviewed. The rebase, error refactor, and remove.rs fixes were prepared with Claude Code under my review, with adversarial review from Codex and Gemini before submission.
