### PR TITLE
Validate git host by exact match and sanitize cache path segments

### DIFF
--- a/packages/opensrc/cli/src/core/cache.rs
+++ b/packages/opensrc/cli/src/core/cache.rs
@@ -77,7 +77,44 @@ pub fn get_repo_display_name(repo_url: &str) -> Option<String> {
     parse_repo_url(repo_url).map(|(host, owner, repo)| format!("{host}/{owner}/{repo}"))
 }
 
+/// Reject any `display_name` or `version` segment that could escape the repos
+/// cache directory via path traversal.
+///
+/// SECURITY: `get_repo_path` joins attacker-influenced strings under
+/// `~/.opensrc/repos` — the repo `display_name` is derived from package
+/// metadata (`repository.url`), and `version`/git-ref is taken verbatim from the
+/// spec after `@`/`#`. Without this check, `fetch vercel/next.js@../../../tmp/evil`
+/// (or a crafted `repository.url` containing `..`) would clone — and later, via
+/// `remove`/`clean`, delete — files OUTSIDE the cache sandbox. Legitimate
+/// slash-bearing branch refs (e.g. `release/1.0`) stay nested INSIDE the cache
+/// and are allowed; only empty, `.`, `..`, or absolute components are rejected.
+fn ensure_safe_path_segment(segment: &str) -> Result<()> {
+    if segment.is_empty() || segment.contains('\0') {
+        return Err(Error::Other(format!(
+            "Unsafe path segment rejected (empty/null): {segment:?}"
+        )));
+    }
+    if segment.starts_with('/')
+        || segment.starts_with('\\')
+        || Path::new(segment).is_absolute()
+    {
+        return Err(Error::Other(format!(
+            "Unsafe path segment rejected (absolute): {segment:?}"
+        )));
+    }
+    for part in segment.split(|c| c == '/' || c == '\\') {
+        if part.is_empty() || part == "." || part == ".." {
+            return Err(Error::Other(format!(
+                "Unsafe path segment rejected (traversal): {segment:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub fn get_repo_path(display_name: &str, version: &str) -> Result<PathBuf> {
+    ensure_safe_path_segment(display_name)?;
+    ensure_safe_path_segment(version)?;
     Ok(get_repos_dir()?.join(display_name).join(version))
 }
 
@@ -297,6 +334,38 @@ mod tests {
         assert_eq!(
             get_repo_display_name("https://github.com/colinhacks/zod"),
             Some("github.com/colinhacks/zod".into())
+        );
+    }
+
+    #[test]
+    fn test_get_repo_path_rejects_traversal_in_version() {
+        // SECURITY: a git-ref / version with `..` must not escape cache.
+        assert!(get_repo_path("github.com/vercel/next.js", "../../../../tmp/evil").is_err());
+        assert!(get_repo_path("github.com/vercel/next.js", "..").is_err());
+        assert!(get_repo_path("github.com/vercel/next.js", "a/../../../b").is_err());
+    }
+
+    #[test]
+    fn test_get_repo_path_rejects_traversal_in_display_name() {
+        assert!(get_repo_path("github.com/../../etc", "1.0.0").is_err());
+        assert!(get_repo_path("../../etc", "1.0.0").is_err());
+    }
+
+    #[test]
+    fn test_get_repo_path_rejects_absolute_segment() {
+        assert!(get_repo_path("github.com/vercel/next.js", "/etc/passwd").is_err());
+        assert!(get_repo_path("github.com/vercel/next.js", "").is_err());
+    }
+
+    #[test]
+    fn test_get_repo_path_allows_slashed_branch_ref() {
+        // Legitimate branch refs containing `/` must still work (stay nested).
+        let p = get_repo_path("github.com/vercel/next.js", "release/1.0")
+            .expect("legit slashed ref must be allowed");
+        let s = p.to_string_lossy().replace('\\', "/");
+        assert!(
+            s.contains("repos/github.com/vercel/next.js/release/1.0"),
+            "path stayed inside repos cache: {s}"
         );
     }
 

--- a/packages/opensrc/cli/src/core/registries/mod.rs
+++ b/packages/opensrc/cli/src/core/registries/mod.rs
@@ -109,8 +109,29 @@ pub fn resolve_package(spec: &PackageSpec) -> super::error::Result<ResolvedPacka
     }
 }
 
+/// Returns the canonical host for `url` **only** if it is one of our supported
+/// git hosts, matched by exact host equality after parsing — never a substring.
+///
+/// SECURITY: clone-target selection and token injection must gate on this, not
+/// on `url.contains("github.com")`. A substring test treats
+/// `https://github.com.attacker.tld/o/r` as GitHub and would leak the token to
+/// `attacker.tld`. Parsing the URL and comparing `host_str()` for exact
+/// equality closes that hole. Only http(s) URLs are considered git repos.
+pub(crate) fn supported_git_host(url: &str) -> Option<&'static str> {
+    let parsed = url::Url::parse(url).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    match parsed.host_str()? {
+        "github.com" => Some("github.com"),
+        "gitlab.com" => Some("gitlab.com"),
+        "bitbucket.org" => Some("bitbucket.org"),
+        _ => None,
+    }
+}
+
 pub(crate) fn is_git_repo_url(url: &str) -> bool {
-    url.contains("github.com") || url.contains("gitlab.com") || url.contains("bitbucket.org")
+    supported_git_host(url).is_some()
 }
 
 pub(crate) fn normalize_repo_url(url: &str) -> String {
@@ -148,34 +169,42 @@ pub(crate) fn bitbucket_token() -> Option<String> {
         .filter(|t| !t.is_empty())
 }
 
-/// Rewrites an HTTPS clone URL to embed auth credentials when a token is available.
+/// Rewrites an HTTPS clone URL to embed auth credentials when a token is
+/// available. Credentials are embedded **only** when the URL's host is exactly
+/// one of the supported git hosts (parsed, not substring-matched) — see
+/// `supported_git_host` for the security rationale. The `replacen` on the
+/// `https://<host>` prefix is safe here precisely because the host has already
+/// been verified equal to that constant, so it can only rewrite the real host.
 pub fn authenticated_clone_url(url: &str) -> String {
-    if let Some(token) = github_token() {
-        if url.contains("github.com") {
-            return url.replacen(
-                "https://github.com",
-                &format!("https://x-access-token:{token}@github.com"),
-                1,
-            );
+    match supported_git_host(url) {
+        Some("github.com") => {
+            if let Some(token) = github_token() {
+                return url.replacen(
+                    "https://github.com",
+                    &format!("https://x-access-token:{token}@github.com"),
+                    1,
+                );
+            }
         }
-    }
-    if let Some(token) = gitlab_token() {
-        if url.contains("gitlab.com") {
-            return url.replacen(
-                "https://gitlab.com",
-                &format!("https://oauth2:{token}@gitlab.com"),
-                1,
-            );
+        Some("gitlab.com") => {
+            if let Some(token) = gitlab_token() {
+                return url.replacen(
+                    "https://gitlab.com",
+                    &format!("https://oauth2:{token}@gitlab.com"),
+                    1,
+                );
+            }
         }
-    }
-    if let Some(token) = bitbucket_token() {
-        if url.contains("bitbucket.org") {
-            return url.replacen(
-                "https://bitbucket.org",
-                &format!("https://x-token-auth:{token}@bitbucket.org"),
-                1,
-            );
+        Some("bitbucket.org") => {
+            if let Some(token) = bitbucket_token() {
+                return url.replacen(
+                    "https://bitbucket.org",
+                    &format!("https://x-token-auth:{token}@bitbucket.org"),
+                    1,
+                );
+            }
         }
+        _ => {}
     }
     url.to_string()
 }
@@ -201,9 +230,52 @@ pub fn detect_input_type(spec: &str) -> &'static str {
 mod tests {
     use super::*;
 
+    // Serializes the env-var-touching tests below so parallel test threads do
+    // not race on GITHUB_TOKEN.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_is_git_repo_url_github() {
         assert!(is_git_repo_url("https://github.com/owner/repo"));
+    }
+
+    #[test]
+    fn test_is_git_repo_url_rejects_substring_host() {
+        // SECURITY: hosts that merely *contain* a supported host as a substring
+        // must NOT be treated as that host.
+        assert!(!is_git_repo_url("https://github.com.attacker.tld/o/r"));
+        assert!(!is_git_repo_url("https://gitlab.com.evil.example/o/r"));
+        assert!(!is_git_repo_url("https://bitbucket.org.evil.example/o/r"));
+        assert!(!is_git_repo_url("https://notgithub.com/o/r"));
+        assert!(!is_git_repo_url("https://github.com@attacker.tld/o/r"));
+    }
+
+    #[test]
+    fn test_authenticated_clone_url_never_leaks_token_to_attacker_host() {
+        // SECURITY: even WITH a token set, an attacker-controlled host that
+        // contains "github.com" as a substring must never receive it.
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("GITHUB_TOKEN", "ghp_SECRETVALUE_DO_NOT_LEAK");
+        let evil = "https://github.com.attacker.tld/owner/repo";
+        let out = authenticated_clone_url(evil);
+        std::env::remove_var("GITHUB_TOKEN");
+        assert_eq!(out, evil, "URL must be returned unchanged for attacker host");
+        assert!(
+            !out.contains("ghp_SECRETVALUE_DO_NOT_LEAK"),
+            "token must not appear in the clone URL"
+        );
+    }
+
+    #[test]
+    fn test_authenticated_clone_url_injects_for_exact_github_host() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("GITHUB_TOKEN", "ghp_SECRETVALUE_DO_NOT_LEAK");
+        let out = authenticated_clone_url("https://github.com/owner/repo");
+        std::env::remove_var("GITHUB_TOKEN");
+        assert_eq!(
+            out,
+            "https://x-access-token:ghp_SECRETVALUE_DO_NOT_LEAK@github.com/owner/repo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two security-hardening fixes in the source-fetching path.

### 1. Match git hosts by exact host, not substring

`is_git_repo_url` and `authenticated_clone_url` decided whether a URL belonged to
`github.com` / `gitlab.com` / `bitbucket.org` using `url.contains("github.com")`.
The URL comes from package metadata (`repository.url`, `project_urls`,
`homepage`), so a look-alike host such as `https://github.com.example.com/owner/repo`
passes the substring test. In `authenticated_clone_url` that means a configured
`GITHUB_TOKEN` / `GITLAB_TOKEN` / `BITBUCKET_TOKEN` is rewritten into the clone
URL and sent to the look-alike host as HTTP basic-auth.

This change parses the URL and compares `host_str()` for **exact equality**
before treating a URL as a supported git host or embedding a token. A new
`supported_git_host()` helper centralises the check so the selection gate and the
token-injection point can't drift apart. The existing `replacen` is now safe
because it only runs once the host is known to equal the constant.

### 2. Sanitise cache path segments

`get_repo_path` joined `display_name` and `version`/git-ref (both derived from
untrusted input — package metadata, and the spec after `@`/`#`) under
`~/.opensrc/repos` with no validation. A ref such as
`vercel/next.js@../../../tmp/x` therefore resolved **outside** the cache
directory, and the same unsanitised path later feeds `remove`/`clean`.

A new `ensure_safe_path_segment()` rejects empty, `.`, `..`, and absolute
components, while still allowing legitimate slash-bearing branch refs (e.g.
`release/1.0`), which stay nested inside the cache.

## Tests

Added regression tests for both issues:

- `registries/mod.rs`: substring-host rejected; token not embedded for a
  look-alike host; token still embedded for an exact host.
- `cache.rs`: traversal rejected in both ref and display name; absolute segment
  rejected; legitimate slashed branch ref allowed.

The full suite passes locally (`cargo test`), and the happy path is unchanged
(e.g. `fetch zod`, `fetch crates:serde` still work).

## Compatibility

No behavioural change for legitimate `github.com` / `gitlab.com` /
`bitbucket.org` URLs or normal version/branch refs.
