### PR TITLE
Prepare v0.7.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,25 @@
 # opensrc
 
-## 0.7.2
+## 0.7.3
 
 <!-- release:start -->
+### Bug Fixes
+
+- **Authenticated clone host validation** — Parse clone URLs and require exact GitHub, GitLab, and Bitbucket hosts before adding tokens, preventing host-prefix confusion attacks (#66)
+
+### Improvements
+
+- **Error handling** — Replace ad hoc boxed errors with a typed error model across the CLI, including cache directory resolution that now returns errors instead of exiting directly (#56)
+- **Fetch documentation** — Document `opensrc fetch` in the CLI README and docs commands page (#56)
+- **Docs search and CI** — Include the authentication page in docs search and add docs type-checking to CI (#56)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.7.2
+
 ### New Features
 
 - **`opensrc fetch` subcommand** — Cache a package's source without printing paths, for use in scripts and CI where you just want the source downloaded (#53)
@@ -18,7 +35,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.7.1
 

--- a/packages/opensrc/cli/Cargo.lock
+++ b/packages/opensrc/cli/Cargo.lock
@@ -662,7 +662,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opensrc"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "clap",

--- a/packages/opensrc/cli/Cargo.toml
+++ b/packages/opensrc/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensrc"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Fetch source code for packages to give coding agents deeper context"
 license = "Apache-2.0"

--- a/packages/opensrc/package.json
+++ b/packages/opensrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensrc",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Fetch source code for packages to give coding agents deeper context",
   "type": "module",
   "bin": {


### PR DESCRIPTION
- Bump opensrc package and Rust crate versions to 0.7.3
- Add v0.7.3 changelog notes and move release markers